### PR TITLE
Import reader/writer from amiga-brain-api

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -26,4 +26,6 @@ jobs:
       run: pip3 install -e .[dev]
     - name: Run Tests
       working-directory: py
-      run: pytest -v tests/ --mypy
+      # TODO: enable mypy later
+      # run: pytest -v tests/ --mypy
+      run: pytest -v tests/

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -22,8 +22,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      working-directory: python
+      working-directory: py
       run: pip3 install -e .[dev]
     - name: Run Tests
-      working-directory: python
+      working-directory: py
       run: pytest -v tests/ --mypy

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -26,6 +26,4 @@ jobs:
       run: pip3 install -e .[dev]
     - name: Run Tests
       working-directory: py
-      # TODO: enable mypy later
-      # run: pytest -v tests/ --mypy
-      run: pytest -v tests/
+      run: pytest -v tests/ --mypy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 venv
+.pytest_cache

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,5 @@
+[MASTER]
+load-plugins=pylint_protobuf
+
 [MESSAGES CONTROL]
 disable=missing-module-docstring,missing-class-docstring,missing-function-docstring

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.testing.pytestArgs": [
+        "py"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.linting.enabled": true,
+	"python.linting.pylintEnabled": true
+}

--- a/cpp/farm_ng/core/prototools/CMakeLists.txt
+++ b/cpp/farm_ng/core/prototools/CMakeLists.txt
@@ -9,17 +9,20 @@ farm_ng_add_library(farm_ng_core_prototools
   INCLUDE_DIR ../../..
   HEADERS
     proto_reader_writer.h
+    event_log_writer.h
+    event_log_reader.h
   SOURCES
     proto_reader_writer.cpp
-
+    event_log_writer.cpp
+    event_log_reader.cpp
 )
 
-target_link_libraries(farm_ng_core_prototools protobuf::libprotobuf farm_ng_core_logging)
+target_link_libraries(farm_ng_core_prototools protobuf::libprotobuf farm_ng_core_logging farm_ng_core_proto_defs)
 
 
-foreach(test_basename proto_reader_writer)
+foreach(test_basename proto_reader_writer event_log_writer)
     farm_ng_add_test(${test_basename}
                           PARENT_LIBRARY farm_ng_core_prototools
-                          LINK_LIBRARIES farm_ng_core_prototools
+                          LINK_LIBRARIES farm_ng_core_prototools farm_ng_core_misc
                           LABELS small)
 endforeach()

--- a/cpp/farm_ng/core/prototools/event_log_reader.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_reader.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Copyright (c) farm-ng, inc. All rights reserved.
+
+#include "farm_ng/core/prototools/event_log_reader.h"
+
+#include "farm_ng/core/logging/logger.h"
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+namespace farm_ng {
+
+class EventLogReaderBinaryImpl : public EventLogReaderImpl {
+ public:
+  EventLogReaderBinaryImpl(std::filesystem::path const& log_path)
+      : log_path(log_path), in(log_path.string(), std::ofstream::binary) {
+    if (!in) {
+      throw std::runtime_error(
+          FARM_FORMAT("Could not open file: {}", log_path));
+    }
+  }
+
+  std::string readBytes(uint64_t n_bytes) {
+    std::string str;
+    str.resize(n_bytes);
+    in.read(str.data(), n_bytes);
+    if (!in) {
+      throw std::runtime_error("Could not read data.");
+    }
+    return str;
+  }
+
+  uint64_t readEventSize() {
+    uint64_t n_bytes = 0;
+    in.read(reinterpret_cast<char*>(&n_bytes), sizeof(n_bytes));
+    if (!in) {
+      throw std::runtime_error("Could not read packet length header");
+    }
+    return n_bytes;
+  }
+
+  virtual std::tuple<core::proto::Event, std::streampos> readNextEvent(
+      std::string* payload = nullptr) override {
+    core::proto::Event event;
+    if (!event.ParseFromString(readBytes(readEventSize()))) {
+      throw std::runtime_error("Could not parse event.");
+    }
+    std::streampos pos = in.tellg();
+    if (payload) {
+      *payload = readBytes(event.payload_length());
+    } else {
+      in.seekg(event.payload_length(), in.cur);
+      if (!in) {
+        throw std::runtime_error("Could not seek past payload.");
+      }
+    }
+    return std::make_tuple(event, pos);
+  }
+  virtual std::string readPayload(
+      core::proto::Event const& event, std::streampos pos) {
+    in.seekg(pos);
+    if (!in) {
+      throw std::runtime_error("Could not seek to read payload.");
+    }
+    return readBytes(event.payload_length());
+  }
+
+  std::filesystem::path getPath() const override { return log_path; }
+
+  std::filesystem::path log_path;
+  std::ifstream in;
+};
+
+namespace {
+void resetImpl(
+    std::unique_ptr<EventLogReaderImpl>& impl,
+    std::filesystem::path const& log_path) {
+  impl = std::make_unique<EventLogReaderBinaryImpl>(log_path);
+}
+}  // namespace
+
+EventLogReader::EventLogReader(std::filesystem::path const& log_path) {
+  resetImpl(impl_, log_path);
+}
+
+EventLogReader::~EventLogReader() { impl_.reset(nullptr); }
+
+std::tuple<core::proto::Event, std::streampos> EventLogReader::readNextEvent(
+    std::string* payload) {
+  return impl_->readNextEvent(payload);
+}
+
+std::string EventLogReader::readPayload(
+    core::proto::Event const& event, std::streampos pos) {
+  return impl_->readPayload(event, pos);
+}
+
+std::filesystem::path EventLogReader::getPath() const {
+  return impl_->getPath();
+}
+
+void EventLogReader::reset() { resetImpl(impl_, impl_->getPath()); }
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/prototools/event_log_reader.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_reader.cpp
@@ -38,7 +38,7 @@ class EventLogReaderBinaryImpl : public EventLogReaderImpl {
   }
 
   uint64_t readEventSize() {
-    uint64_t n_bytes = 0;
+    uint32_t n_bytes = 0;
     in.read(reinterpret_cast<char*>(&n_bytes), sizeof(n_bytes));
     if (!in) {
       throw std::runtime_error("Could not read packet length header");

--- a/cpp/farm_ng/core/prototools/event_log_reader.h
+++ b/cpp/farm_ng/core/prototools/event_log_reader.h
@@ -1,0 +1,68 @@
+// Copyright (c) farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Copyright (c) farm-ng, inc. All rights reserved.
+
+#pragma once
+
+#include "farm_ng/core/event.pb.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace farm_ng {
+
+/// Implementation of the `EventLogReader` class
+///
+class EventLogReaderImpl {
+ public:
+  /// https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-dtor
+  virtual ~EventLogReaderImpl() {}
+
+  /// Returns next event.
+  virtual std::tuple<core::proto::Event, std::streampos> readNextEvent(
+      std::string* payload = nullptr) = 0;
+
+  virtual std::string readPayload(
+      core::proto::Event const& event, std::streampos pos) = 0;
+
+  /// Returns the path including the fileaname
+  virtual std::filesystem::path getPath() const = 0;
+};
+
+/// Reader to deserialize data written by the EventLogWriter.
+///
+class EventLogReader {
+ public:
+  /// Open's log file to read.
+  ///
+  /// Throws runtime-error if files could not be opened or if logfile does not
+  /// contain a valid header.
+  explicit EventLogReader(std::filesystem::path const& log_path);
+
+  EventLogReader(EventLogReader&&) = default;
+  EventLogReader& operator=(EventLogReader&&) = default;
+
+  /// https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-dtor
+  virtual ~EventLogReader();
+
+  std::tuple<core::proto::Event, std::streampos> readNextEvent(
+      std::string* payload = nullptr);
+
+  std::string readPayload(core::proto::Event const& event, std::streampos pos);
+
+  /// Returns the path including the fileaname
+  std::filesystem::path getPath() const;
+
+  /// Reset the writer to the beginning of the file
+  void reset();
+
+ private:
+  std::unique_ptr<EventLogReaderImpl> impl_;
+};
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/prototools/event_log_writer.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_writer.cpp
@@ -73,7 +73,7 @@ class EventLogWriterBinaryImpl : public EventLogWriterImpl {
     event.set_payload_length(payload.size());
     std::string event_str;
     event.SerializeToString(&event_str);
-    uint64_t n_bytes = event_str.size();
+    uint32_t n_bytes = event_str.size();
     out.write(reinterpret_cast<char const*>(&n_bytes), sizeof(n_bytes));
     out << event_str;
     out << payload;

--- a/cpp/farm_ng/core/prototools/event_log_writer.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_writer.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Copyright (c) farm-ng, inc. All rights reserved.
+
+#include "farm_ng/core/prototools/event_log_writer.h"
+
+#include <farm_ng/core/logging/logger.h>
+#include <unistd.h>
+
+#include <climits>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+char hostname[HOST_NAME_MAX];
+char username[LOGIN_NAME_MAX];
+
+namespace farm_ng {
+namespace {
+std::string getAuthoritySlow() {
+  char hostname[HOST_NAME_MAX];
+  gethostname(hostname, HOST_NAME_MAX);
+  return std::string(hostname);
+}
+std::string const& getAuthority() {
+  static std::string host_name = getAuthoritySlow();
+  return host_name;
+}
+double monotonic() {
+  double now = 1e-6 * std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now().time_since_epoch())
+                          .count();
+  return now;
+}
+core::proto::Timestamp makeWriteStamp() {
+  core::proto::Timestamp stamp;
+  stamp.set_stamp(monotonic());
+  stamp.set_semantics("log/write");
+  stamp.set_clock_name(getAuthority() + "/monotonic");
+  return stamp;
+}
+
+}  // namespace
+
+class EventLogWriterBinaryImpl : public EventLogWriterImpl {
+ public:
+  EventLogWriterBinaryImpl(std::filesystem::path const& log_path)
+      : log_path(log_path), out(log_path.string(), std::ofstream::binary) {}
+
+  void write(
+      std::string path,
+      google::protobuf::Message const& message,
+      std::vector<core::proto::Timestamp> const& timestamps) override {
+    std::string payload;
+    message.SerializeToString(&payload);
+    core::proto::Event event;
+    // see py/farm_ng/core/uri.py
+    core::proto::Uri* uri = event.mutable_uri();
+    uri->set_scheme("protobuf");
+    uri->set_authority(getAuthority());
+    uri->set_path(path);
+    uri->set_query("type=" + message.GetDescriptor()->full_name());
+
+    for (core::proto::Timestamp const& stamp : timestamps) {
+      event.add_timestamps()->CopyFrom(stamp);
+    }
+    event.add_timestamps()->CopyFrom(makeWriteStamp());
+    event.set_payload_length(payload.size());
+    std::string event_str;
+    event.SerializeToString(&event_str);
+    uint64_t n_bytes = event_str.size();
+    out.write(reinterpret_cast<char const*>(&n_bytes), sizeof(n_bytes));
+    out << event_str;
+    out << payload;
+    out.flush();
+  }
+
+  std::filesystem::path log_path;
+  std::ofstream out;
+};
+
+EventLogWriter::EventLogWriter(std::filesystem::path const& log_path) noexcept
+    : log_path_(log_path) {
+  // generate the directory tree in case it's empty or doesn't exist
+
+  std::filesystem::path path_prefix = log_path;
+  path_prefix.remove_filename();
+
+  if (!std::filesystem::exists(path_prefix)) {
+    FARM_CHECK(
+        std::filesystem::create_directories(path_prefix),
+        "Could not create the directory: {}. It might exist already, please "
+        "check it out",
+        path_prefix);
+  }
+  impl_ = std::make_unique<EventLogWriterBinaryImpl>(log_path);
+}
+
+EventLogWriter::~EventLogWriter() noexcept { impl_.reset(nullptr); }
+
+void EventLogWriter::write(
+    std::string path,
+    google::protobuf::Message const& message,
+    std::vector<core::proto::Timestamp> const& timestamps) {
+  impl_->write(path, message, timestamps);
+}
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/prototools/event_log_writer.h
+++ b/cpp/farm_ng/core/prototools/event_log_writer.h
@@ -1,0 +1,63 @@
+// Copyright (c) farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Copyright (c) farm-ng, inc. All rights reserved.
+
+#pragma once
+
+#include "farm_ng/core/event.pb.h"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace farm_ng {
+
+/// Implementation of the `EventLogWriter` class
+///
+class EventLogWriterImpl {
+ public:
+  /// https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-dtor
+  virtual ~EventLogWriterImpl() {}
+
+  virtual void write(
+      std::string path,
+      google::protobuf::Message const& message,
+      std::vector<core::proto::Timestamp> const& timestamps) = 0;
+};
+
+/// Class that serializes incoming protobuf events to a file in disk.
+class EventLogWriter {
+ public:
+  /// Main constructor of the class.
+  ///
+  /// Precondition: It must be possible to create the folder ``log_path_`` if it
+  /// does not exist. If ``log-path`` does exist, it must be a folder and it
+  /// must be empty.
+  ///
+  EventLogWriter(std::filesystem::path const& log_path) noexcept;
+
+  /// Main destructor
+  virtual ~EventLogWriter() noexcept;
+
+  /// Writes an incoming protobuf in the log file
+  void write(
+      std::string path,
+      google::protobuf::Message const& message,
+      std::vector<core::proto::Timestamp> const& timestamps =
+          std::vector<core::proto::Timestamp>());
+
+  /// Returns the path including the fileaname
+  std::filesystem::path getPath() const { return log_path_; }
+
+ private:
+  // The log path including the filename
+  std::filesystem::path log_path_;
+  // Implementation pointer of the class
+  std::unique_ptr<EventLogWriterImpl> impl_;
+};
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/prototools/event_log_writer_test.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_writer_test.cpp
@@ -12,7 +12,6 @@
 
 #include <farm_ng/core/logging/logger.h>
 #include <farm_ng/core/misc/filesystem.h>
-#include <google/protobuf/wrappers.pb.h>
 #include <gtest/gtest.h>
 
 using namespace farm_ng;
@@ -30,10 +29,10 @@ TEST(event_log, roundtrip) {
   auto file = log_dir / "events.log";
   {
     EventLogWriter writer(file);
-    google::protobuf::Int32Value x;
+    core::proto::Timestamp x;
     for (int i = 0; i < 10; ++i) {
-      x.set_value(i);
-      writer.write("my_ints", x);
+      x.set_stamp(i);
+      writer.write("my_stamps", x);
     }
   }
   {
@@ -41,13 +40,13 @@ TEST(event_log, roundtrip) {
     for (int i = 0; i < 10; ++i) {
       std::string payload;
       auto [event, pos] = reader.readNextEvent(&payload);
-      google::protobuf::Int32Value x;
+      core::proto::Timestamp x;
       EXPECT_EQ(true, x.ParseFromString(payload));
-      EXPECT_EQ(i, x.value());
+      EXPECT_EQ(i, x.stamp());
       EXPECT_EQ("protobuf", event.uri().scheme());
-      EXPECT_EQ("my_ints", event.uri().path());
+      EXPECT_EQ("my_stamps", event.uri().path());
       EXPECT_EQ(getHostName(), event.uri().authority());
-      EXPECT_EQ("type=google.protobuf.Int32Value", event.uri().query());
+      EXPECT_EQ("type=farm_ng.core.proto.Timestamp", event.uri().query());
     }
     EXPECT_THROW(reader.readNextEvent(), std::runtime_error);
   }

--- a/cpp/farm_ng/core/prototools/event_log_writer_test.cpp
+++ b/cpp/farm_ng/core/prototools/event_log_writer_test.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+// Copyright (c) farm-ng, inc. All rights reserved.
+
+#include "farm_ng/core/prototools/event_log_writer.h"
+
+#include "farm_ng/core/prototools/event_log_reader.h"
+
+#include <farm_ng/core/logging/logger.h>
+#include <farm_ng/core/misc/filesystem.h>
+#include <google/protobuf/wrappers.pb.h>
+#include <gtest/gtest.h>
+
+using namespace farm_ng;
+namespace {
+std::string getHostName() {
+  char hostname[HOST_NAME_MAX];
+  gethostname(hostname, HOST_NAME_MAX);
+  return std::string(hostname);
+}
+}  // namespace
+
+TEST(event_log, roundtrip) {
+  auto maybe_log_dir = createUniqueTemporaryDirectory();
+  auto log_dir = FARM_UNWRAP(maybe_log_dir);
+  auto file = log_dir / "events.log";
+  {
+    EventLogWriter writer(file);
+    google::protobuf::Int32Value x;
+    for (int i = 0; i < 10; ++i) {
+      x.set_value(i);
+      writer.write("my_ints", x);
+    }
+  }
+  {
+    EventLogReader reader(file);
+    for (int i = 0; i < 10; ++i) {
+      std::string payload;
+      auto [event, pos] = reader.readNextEvent(&payload);
+      google::protobuf::Int32Value x;
+      EXPECT_EQ(true, x.ParseFromString(payload));
+      EXPECT_EQ(i, x.value());
+      EXPECT_EQ("protobuf", event.uri().scheme());
+      EXPECT_EQ("my_ints", event.uri().path());
+      EXPECT_EQ(getHostName(), event.uri().authority());
+      EXPECT_EQ("type=google.protobuf.Int32Value", event.uri().query());
+    }
+    EXPECT_THROW(reader.readNextEvent(), std::runtime_error);
+  }
+}

--- a/protos/farm_ng/core/event.proto
+++ b/protos/farm_ng/core/event.proto
@@ -16,3 +16,8 @@ message Event {
   repeated Timestamp timestamps = 2;
   int64 payload_length = 3;
 }
+
+// TODO(edgar): remove after transition to new setup
+message EventHeader {
+  string robot_name = 1;
+}

--- a/protos/farm_ng/core/event.proto
+++ b/protos/farm_ng/core/event.proto
@@ -16,8 +16,3 @@ message Event {
   repeated Timestamp timestamps = 2;
   int64 payload_length = 3;
 }
-
-// TODO(edgar): remove after transition to new setup
-message EventHeader {
-  string robot_name = 1;
-}

--- a/py/README.md
+++ b/py/README.md
@@ -1,0 +1,46 @@
+# farm-ng-core [python]
+
+## Install
+
+Install `pip3` & `virtualenv`:
+
+```bash
+sudo apt-get install python3-pip
+sudo pip3 install virtualenv
+```
+
+Clone the project:
+
+```bash
+git clone https://github.com/farm-ng/farm-ng-core.git
+```
+
+Move to the python code directory:
+
+```bash
+cd farm-ng-core/py
+```
+
+Start a virtual environment:
+
+```bash
+# assuming you're already in the amiga-brain-api/ directory
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Create and install the `farm_ng.core` package:
+
+```bash
+# install to system
+pip3 install .
+
+# or for development mode
+pip3 install -e .[dev]
+```
+
+Verify that you have installed the package
+
+```bash
+python3 -c "import farm_ng; print(farm_ng.__version__)"
+```

--- a/py/README.md
+++ b/py/README.md
@@ -24,7 +24,7 @@ cd farm-ng-core/py
 Start a virtual environment:
 
 ```bash
-# assuming you're already in the amiga-brain-api/ directory
+# assuming you're already in farm-ng-core/py directory
 python3 -m venv venv
 source venv/bin/activate
 ```

--- a/py/farm_ng/__init__.py
+++ b/py/farm_ng/__init__.py
@@ -1,9 +1,0 @@
-# Version variable
-import sys
-
-if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
-    import importlib.metadata as importlib_metadata
-else:  # pragma: <3.8 cover
-    import importlib_metadata
-
-__version__ = importlib_metadata.version("farm_ng")

--- a/py/farm_ng/__init__.py
+++ b/py/farm_ng/__init__.py
@@ -1,5 +1,3 @@
-from farm_ng import core
-
 # Version variable
 import sys
 

--- a/py/farm_ng/core/__init__.py
+++ b/py/farm_ng/core/__init__.py
@@ -1,0 +1,9 @@
+# Version variable
+import sys
+
+if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
+    import importlib.metadata as importlib_metadata
+else:  # pragma: <3.8 cover
+    import importlib_metadata
+
+__version__ = importlib_metadata.version("farm_ng")

--- a/py/farm_ng/core/__init__.py
+++ b/py/farm_ng/core/__init__.py
@@ -6,4 +6,4 @@ if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
 else:  # pragma: <3.8 cover
     import importlib_metadata
 
-__version__ = importlib_metadata.version("farm_ng")
+__version__ = importlib_metadata.version("farm_ng_core")

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -12,6 +12,7 @@ import os
 from farm_ng.core.event_pb2 import Event
 from farm_ng.core.uri_pb2 import Uri
 from farm_ng.core.uri import uri_to_string, string_to_uri
+from google.protobuf.message import Message
 
 
 def parse_protobuf_descriptor(uri: Uri) -> Tuple[str, str]:
@@ -40,7 +41,7 @@ class EventsFileReader:
         # store the bytes offset in a dictionary where:
         # - the key is the string representation of the Uri of the message
         # - the value is a list of offsets to messages with that Uri
-        self._offsets: DefaultDict[str, List[int]] = defaultdict(list)
+        self._event_index: DefaultDict[str, List[Tuple(Event, int)]] = defaultdict(list)
 
     def __enter__(self):
         self.open()
@@ -83,18 +84,18 @@ class EventsFileReader:
         self._file_stream = None
         return self.is_closed()
 
-    def reset_offsets(self) -> None:
-        self._offsets = defaultdict(list)
+    def _reset_event_index(self) -> None:
+        self._event_index = defaultdict(list)
 
     def uris(self) -> List[Uri]:
-        if len(self._offsets) == 0:
-            self._compute_offsets()
-        return [string_to_uri(key) for key in sorted(self._offsets.keys())]
+        if not self._event_index:
+            self._build_event_index()
+        return [string_to_uri(key) for key in sorted(self._event_index.keys())]
 
     def has_uri(self, uri: Uri) -> bool:
-        if self._offsets is None:
+        if self._event_index is None:
             return False
-        return uri_to_string(uri) in self._offsets.keys()
+        return uri_to_string(uri) in self._event_index.keys()
 
     def _read_next_event(self) -> Event:
         buffer = self._file_stream.read(4)
@@ -111,7 +112,7 @@ class EventsFileReader:
         msg_bytes: int = event.payload_length
         self._file_stream.seek(msg_bytes, 1)
 
-    def _compute_offsets(self) -> None:
+    def _build_event_index(self) -> None:
         if not self.is_open():
             raise Exception("Reader not open. Please, use reader.open()")
 
@@ -119,40 +120,38 @@ class EventsFileReader:
         file_stream.seek(0)
 
         # clear, if any the previous offsets
-        self.reset_offsets()
+        self._reset_event_index()
         while True:
-            current_offset = file_stream.tell()
             try:
                 event = self._read_next_event()
-                self._offsets[uri_to_string(event.uri)].append(current_offset)
+                current_offset = file_stream.tell()
+                self._event_index[uri_to_string(event.uri)].append(
+                    (event, current_offset)
+                )
                 self._skip_next_message(event)
             except EOFError:
                 break
 
         file_stream.seek(0)
 
-    def offsets(self, uri: Uri) -> List[int]:
-        return self._offsets[uri_to_string(uri)]
+    def events(self, uri: Uri) -> List[Tuple[Event, int]]:
+        if not self._event_index:
+            self._build_event_index()
+        return self._event_index[uri_to_string(uri)]
 
-    def num_frames(self, uri: Uri) -> int:
-        if not self._offsets:
-            self._compute_offsets()
+    def num_events(self, uri: Uri) -> int:
         if not self.has_uri(uri):
             return 0
-        return len(self.offsets(uri))
+        return len(self.events(uri))
 
-    def seek(self, uri: Uri, frame_id: int) -> None:
+    def get_event(self, uri: Uri, frame_id: int) -> Tuple[Event, int]:
         assert self.has_uri(uri)
-        assert frame_id < self.num_frames(uri)
-        assert self.is_open()
+        assert frame_id < self.num_events(uri)
+        return self.events(uri)[frame_id]
 
-        file_stream = cast(IO, self._file_stream)
-        file_stream.seek(self._offsets[uri_to_string(uri)][frame_id])
-
-    def read(self) -> Tuple[Event, Any]:
-        assert self.is_open()
-        event = self._read_next_event()
-
+    def read_message(self, event: Event, offset: Optional[int] = None) -> Message:
+        if offset is not None:
+            self._file_stream.seek(offset, 0)
         name, package = parse_protobuf_descriptor(event.uri)
         message_cls = getattr(importlib.import_module(package), name)
 
@@ -161,8 +160,12 @@ class EventsFileReader:
 
         message = message_cls()
         message.ParseFromString(payload)
+        return message
 
-        return event, message
+    def read(self) -> Tuple[Event, Message]:
+        assert self.is_open()
+        event = self._read_next_event()
+        return event, self.read_message(event)
 
     def read_messages(self):
         self._file_stream.seek(0)

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -93,7 +93,7 @@ class EventsFileReader:
     def uris(self) -> List[Uri]:
         if self.offsets is None:
             return []
-        return [string_to_uri(key) for key in self.offsets.keys()]
+        return [string_to_uri(key) for key in sorted(self.offsets.keys())]
 
     def has_uri(self, uri: Uri) -> bool:
         if self.offsets is None:

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -23,14 +23,20 @@ def parse_protobuf_descriptor(uri: Uri) -> Tuple[str, str]:
     type_split = uri.query.split("type=")
     assert len(type_split) == 2
     desc = type_split[1].split("&")[0]  # query string can have multiple key/value pairs
-    desc_list = desc.split(".")
-    name = desc_list[-1]
-    package = desc_list[:-2] + [name.lower() + "_pb2"]
-    return name, ".".join(package)
+
+    if desc.startswith("farm_ng"):
+        desc_list = desc.split(".")
+        name = desc_list[-1]
+        package = desc_list[:-2] + [name.lower() + "_pb2"]
+        return name, ".".join(package)
+    else:
+        assert False, ("Unsupported protobuf type:", desc)
 
 
 class EventsFileReader:
     def __init__(self, file_name: Path) -> None:
+        if type(file_name) is str:
+            file_name = Path(file_name)
         self._file_name = file_name.absolute()
         assert Path(self._file_name.parents[0]).is_dir(), self._file_name
         assert self._file_name.exists(), self._file_name

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -1,14 +1,15 @@
 import importlib
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
+from typing import Tuple
 from typing import cast
 from typing import DefaultDict
 from typing import IO
 from typing import List
 from typing import Optional
+from typing import Union
 import struct
-import os
 from farm_ng.core.event_pb2 import Event
 from farm_ng.core.uri_pb2 import Uri
 from farm_ng.core.uri import uri_to_string, string_to_uri
@@ -17,43 +18,43 @@ from google.protobuf.message import Message
 
 def parse_protobuf_descriptor(uri: Uri) -> Tuple[str, str]:
     assert uri.scheme == "protobuf"
-    # parse a proto descriptor and extract the message name and package.
-    # See: https://developers.google.com/protocol-buffers/docs/reference/python-generated#invocation
-    # NOTE: the descriptor comes in the shape of `farm_ng.core.proto.Timestamp`
     type_split = uri.query.split("type=")
     assert len(type_split) == 2
     desc = type_split[1].split("&")[0]  # query string can have multiple key/value pairs
 
-    if desc.startswith("farm_ng"):
-        desc_list = desc.split(".")
-        name = desc_list[-1]
-        package = desc_list[:-2] + [name.lower() + "_pb2"]
-        return name, ".".join(package)
-    else:
-        assert False, ("Unsupported protobuf type:", desc)
+    if not desc.startswith("farm_ng"):
+        raise Exception(f"Unsupported protobuf type: {desc}")
+
+    # parse a proto descriptor and extract the message name and package.
+    # See: https://developers.google.com/protocol-buffers/docs/reference/python-generated#invocation
+    # NOTE: the descriptor comes in the shape of `farm_ng.core.proto.Timestamp`
+    desc_list = desc.split(".")
+    name = desc_list[-1]
+    package = desc_list[:-2] + [name.lower() + "_pb2"]
+    return name, ".".join(package)
 
 
 class EventsFileReader:
-    def __init__(self, file_name: Path) -> None:
-        if type(file_name) is str:
+    def __init__(self, file_name: Union[str, Path]) -> None:
+        if isinstance(file_name, str):
             file_name = Path(file_name)
-        self._file_name = file_name.absolute()
-        assert Path(self._file_name.parents[0]).is_dir(), self._file_name
+        self._file_name: Path = file_name.absolute()
         assert self._file_name.exists(), self._file_name
+
         self._file_stream: Optional[IO] = None
         self._file_length: int = 0
 
-        # assert self.open()
         # store the bytes offset in a dictionary where:
         # - the key is the string representation of the Uri of the message
-        # - the value is a list of offsets to messages with that Uri
-        self._event_index: DefaultDict[str, List[Tuple(Event, int)]] = defaultdict(list)
+        # - the value is a list with tuples of Event and its offsets to messages with that Uri
+        self._event_index: DefaultDict[str, List[Tuple[Event, int]]] = defaultdict(list)
 
-    def __enter__(self):
-        self.open()
+    def __enter__(self) -> "EventsFileReader":
+        assert self.open()
         return self
 
-    def __exit__(self, type, value, traceback):
+    # pylint: disable=redefined-builtin
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
         self.close()
 
     def __repr__(self) -> str:
@@ -64,10 +65,12 @@ class EventsFileReader:
         )
 
     @property
-    def file_name(self) -> Optional[Path]:
-        if self._file_stream is None:
-            return None
-        return Path(self._file_stream.name)
+    def file_length(self) -> int:
+        return self._file_length
+
+    @property
+    def file_name(self) -> Path:
+        return self._file_name
 
     def is_open(self) -> bool:
         return not self.is_closed()
@@ -79,7 +82,7 @@ class EventsFileReader:
 
     def open(self) -> bool:
         self._file_stream = open(self._file_name, "rb")
-        self._file_length = os.path.getsize(self._file_name)
+        self._file_length = self._file_name.stat().st_size
         return self.is_open()
 
     def close(self) -> bool:
@@ -104,19 +107,21 @@ class EventsFileReader:
         return uri_to_string(uri) in self._event_index.keys()
 
     def _read_next_event(self) -> Event:
-        buffer = self._file_stream.read(4)
+        file_stream = cast(IO, self._file_stream)
+        buffer = file_stream.read(4)
         if len(buffer) != 4:
             raise EOFError()
 
         event_len = struct.unpack("<I", buffer)[0]
-        event_bytes: bytes = self._file_stream.read(event_len)
+        event_bytes: bytes = file_stream.read(event_len)
         event = Event()
         event.ParseFromString(event_bytes)
         return event
 
     def _skip_next_message(self, event: Event) -> None:
         msg_bytes: int = event.payload_length
-        self._file_stream.seek(msg_bytes, 1)
+        file_stream = cast(IO, self._file_stream)
+        file_stream.seek(msg_bytes, 1)
 
     def _build_event_index(self) -> None:
         if not self.is_open():
@@ -156,15 +161,15 @@ class EventsFileReader:
         return self.events(uri)[frame_id]
 
     def read_message(self, event: Event, offset: Optional[int] = None) -> Message:
+        file_stream = cast(IO, self._file_stream)
         if offset is not None:
-            self._file_stream.seek(offset, 0)
+            file_stream.seek(offset, 0)
         name, package = parse_protobuf_descriptor(event.uri)
         message_cls = getattr(importlib.import_module(package), name)
 
-        file_stream = cast(IO, self._file_stream)
         payload: bytes = file_stream.read(event.payload_length)
 
-        message = message_cls()
+        message: Message = message_cls()
         message.ParseFromString(payload)
         return message
 

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -9,17 +9,21 @@ from typing import DefaultDict
 from typing import IO
 from typing import List
 from typing import Optional
-import logging
+import struct
+import os
+from farm_ng.core.event_pb2 import Event
+from farm_ng.core.uri_pb2 import Uri
+from farm_ng.core.uri import uri_to_string, string_to_uri
 
-from farm_ng.core import event_pb2
-from farm_ng.core.uri import Uri
-from farm_ng.core import uri_pb2
 
-
-def parse_protobuf_descriptor(desc) -> Tuple[str, str]:
+def parse_protobuf_descriptor(uri: Uri) -> Tuple[str, str]:
+    assert uri.scheme == "protobuf"
     # parse a proto descriptor and extract the message name and package.
     # See: https://developers.google.com/protocol-buffers/docs/reference/python-generated#invocation
     # NOTE: the descriptor comes in the shape of `farm_ng.core.proto.Timestamp`
+    type_split = uri.query.split("type=")
+    assert len(type_split) == 2
+    desc = type_split[1].split("&")[0]  # query string can have multiple key/value pairs
     desc_list = desc.split(".")
     name = desc_list[-1]
     package = desc_list[:-2] + [name.lower() + "_pb2"]
@@ -28,70 +32,32 @@ def parse_protobuf_descriptor(desc) -> Tuple[str, str]:
 
 class EventsFileReader:
     def __init__(self, file_name: Path) -> None:
-        self.logger = logging.getLogger(self.__class__.__name__)
-
         self._file_name = file_name.absolute()
-        assert Path(self._file_name.parents[0]).is_dir()
-
+        assert Path(self._file_name.parents[0]).is_dir(), self._file_name
+        assert self._file_name.exists(), self._file_name
         self._file_stream: Optional[IO] = None
+        self._file_length: int = 0
+
         # assert self.open()
         # store the bytes offset in a dictionary where:
         # - the key is the string representation of the Uri of the message
         # - the value is a list of offsets to messages with that Uri
-        self.offsets: DefaultDict[str, List[int]] = defaultdict(list)
+        self.offsets: DefaultDict[Uri, List[int]] = defaultdict(list)
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
 
     def __repr__(self) -> str:
         return (
-            f"file_name: {str(self.file_name)}\n"
-            f"file_stream: {self._file_stream}\nis_open: {self.is_open}"
+            f"file_name: {str(self.file_name)} "
+            + f"file_stream: {self._file_stream} "
+            + f"is_open: {self.is_open()} "
+            + f"file_length: {self.file_length}"
         )
-
-    def reset_offsets(self) -> None:
-        self.offsets = defaultdict(list)
-
-    def uris(self) -> List[Uri]:
-        if self.offsets is None:
-            return []
-        return [Uri.from_string(key) for key in self.offsets.keys()]
-
-    def has_uri(self, uri) -> bool:
-        if self.offsets is None:
-            return False
-        return uri.string() in self.offsets.keys()
-
-    def _read_next_event(self) -> Optional[event_pb2.Event]:
-        event_len = int.from_bytes(self._file_stream.read(4), sys.byteorder)
-        # end file condition
-        if event_len == 0:
-            self._file_stream.seek(0)
-            return None
-
-        event_bytes: bytes = self._file_stream.read(event_len)
-
-        event = event_pb2.Event()
-        event.ParseFromString(event_bytes)
-        return event
-
-    def _skip_next_message(self, event: event_pb2.Event) -> None:
-        msg_bytes: int = event.payload_length
-        self._file_stream.seek(msg_bytes, 4)
-
-    def _compute_offsets(self) -> None:
-        if not self.is_open:
-            raise Exception("Reader not open. Please, use reader.open()")
-
-        # clear, if any the previous offsets
-        self.reset_offsets()
-
-        while True:
-            current_offset = self._file_stream.tell()
-            maybe_event = self._read_next_event()
-            if maybe_event is None:
-                return
-            event = cast(event_pb2.Event, maybe_event)
-            uri = Uri(event.uri)
-            self.offsets[uri.string()].append(current_offset)
-            self._skip_next_message(event)
 
     @property
     def file_name(self) -> Optional[Path]:
@@ -109,56 +75,100 @@ class EventsFileReader:
 
     def open(self) -> bool:
         self._file_stream = open(self._file_name, "rb")
+        self._file_length = os.path.getsize(self._file_name)
         self._compute_offsets()
         return self.is_open()
 
     def close(self) -> bool:
-        if self._file_stream is not None:
-            self._file_stream.close()
-            self._file_stream = None
+        if self.is_closed():
+            return True
+        file_stream = cast(IO, self._file_stream)
+        file_stream.close()
+        self._file_stream = None
         return self.is_closed()
+
+    def reset_offsets(self) -> None:
+        self.offsets = defaultdict(list)
+
+    def uris(self) -> List[Uri]:
+        if self.offsets is None:
+            return []
+        return [string_to_uri(key) for key in self.offsets.keys()]
+
+    def has_uri(self, uri: Uri) -> bool:
+        if self.offsets is None:
+            return False
+        return uri_to_string(uri) in self.offsets.keys()
+
+    def _read_next_event(self) -> Event:
+        buffer = self._file_stream.read(4)
+        if len(buffer) != 4:
+            raise EOFError()
+
+        event_len = struct.unpack("<I", buffer)[0]
+        event_bytes: bytes = self._file_stream.read(event_len)
+        event = Event()
+        event.ParseFromString(event_bytes)
+        return event
+
+    def _skip_next_message(self, event: Event) -> None:
+        msg_bytes: int = event.payload_length
+        self._file_stream.seek(msg_bytes, 1)
+
+    def _compute_offsets(self) -> None:
+        if not self.is_open():
+            raise Exception("Reader not open. Please, use reader.open()")
+
+        file_stream = cast(IO, self._file_stream)
+        file_stream.seek(0)
+
+        # clear, if any the previous offsets
+        self.reset_offsets()
+        while True:
+            current_offset = file_stream.tell()
+            try:
+                event = self._read_next_event()
+                self.offsets[uri_to_string(event.uri)].append(current_offset)
+                self._skip_next_message(event)
+            except EOFError:
+                break
+
+        file_stream.seek(0)
 
     def num_frames(self, uri: Uri) -> int:
         if not self.offsets:
             self._compute_offsets()
-        if uri.string() not in self.offsets.keys():
-            return -1
-        return len(self.offsets[uri.string()])
+        if not self.has_uri(uri):
+            return 0
+        return len(self.offsets[uri])
 
     def seek(self, uri: Uri, frame_id: int) -> None:
-        assert uri.string() in self.offsets.keys()
+        assert uri in self.offsets.keys()
         assert frame_id < self.num_frames(uri)
-        maybe_file_stream = self._file_stream
-        if maybe_file_stream is None:
-            return
-        file_stream = cast(IO, maybe_file_stream)
-        file_stream.seek(self.offsets[uri.string()][frame_id])
+        assert self.is_open()
 
-    def read(self) -> Optional[Tuple[event_pb2.Event, Any]]:
-        # Read the message's length as bytes and convert it to an integer
-        maybe_file_stream = self._file_stream
-        if maybe_file_stream is None:
-            return None
-        file_stream = cast(IO, maybe_file_stream)
+        file_stream = cast(IO, self._file_stream)
+        file_stream.seek(self.offsets[uri_to_string(uri)][frame_id])
 
-        event_len = int.from_bytes(file_stream.read(4), sys.byteorder)
-        if event_len == 0:
-            self.close()
-            return None
+    def read(self) -> Tuple[Event, Any]:
+        assert self.is_open()
+        event = self._read_next_event()
 
-        # Read that number of bytes as the message bytes
-        event: bytes = file_stream.read(event_len)
-
-        event_proto = event_pb2.Event()
-        event_proto.ParseFromString(event)
-
-        # parse the message
-        name, package = parse_protobuf_descriptor(event_proto.uri.scheme)
+        name, package = parse_protobuf_descriptor(event.uri)
         message_cls = getattr(importlib.import_module(package), name)
 
-        message: bytes = file_stream.read(event_proto.payload_length)
+        file_stream = cast(IO, self._file_stream)
+        payload: bytes = file_stream.read(event.payload_length)
 
-        message_out = message_cls()
-        message_out.ParseFromString(message)
+        message = message_cls()
+        message.ParseFromString(payload)
 
-        return event_proto, message_out
+        return event, message
+
+    def read_messages(self):
+        try:
+            while True:
+                event, message = self.read()
+                yield event, message
+        except EOFError:
+            pass

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -2,14 +2,16 @@ import importlib
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
-from typing import BinaryIO
-from typing import Dict
+from typing import Any, Tuple
+from typing import cast
+from typing import DefaultDict
+from typing import IO
 from typing import List
 from typing import Optional
 
 from farm_ng.core import event_pb2
 from farm_ng.core.uri import Uri
+from farm_ng.core import uri_pb2
 
 
 class EventsFileReader:
@@ -17,30 +19,41 @@ class EventsFileReader:
         self._file_name = file_name.absolute()
         assert Path(self._file_name.parents[0]).is_dir()
 
-        self._file_stream: Optional[BinaryIO] = None
+        self._file_stream: Optional[IO] = None
         # assert self.open()
         # store the bytes offset in a dictionary where:
         # - the key is the string representation of the Uri of the message
         # - the value is a list of offsets to messages with that Uri
-        self.offsets: Optional[Dict[str, List[int]]] = None
+        self.offsets: DefaultDict[str, List[int]] = defaultdict(list)
         # self.compute_offsets()
 
     def __repr__(self) -> str:
-        return f"file_name: {str(self.file_name)}\nfile_stream: {self._file_stream}\nis_open: {self.is_open}"
+        return (
+            f"file_name: {str(self.file_name)}\n"
+            f"file_stream: {self._file_stream}\nis_open: {self.is_open}"
+        )
 
     def reset_offsets(self) -> None:
         self.offsets = defaultdict(list)
 
     def uris(self) -> List[Uri]:
+        if self.offsets is None:
+            return []
         return [Uri.from_string(key) for key in self.offsets.keys()]
 
     def has_uri(self, uri) -> bool:
+        if self.offsets is None:
+            return False
         return uri.string() in self.offsets.keys()
 
-    # TODO: discuss the api signature
-    def compute_offsets(self) -> Dict[Uri, List[int]]:
+    def compute_offsets(self) -> None:
         if not self.is_open:
             raise Exception("Reader not open. Please, use reader.open()")
+
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return None
+        file_stream = cast(IO, maybe_file_stream)
 
         # clear, if any the previous offsets
         self.reset_offsets()
@@ -54,16 +67,17 @@ class EventsFileReader:
         assert header is not None
 
         current_offset += 1 + header.ByteSize()
+        header_offset = current_offset
 
         while True:
 
-            event_len = int.from_bytes(self._file_stream.read(1), sys.byteorder)
+            event_len = int.from_bytes(file_stream.read(1), sys.byteorder)
             # end file condition
             if event_len == 0:
-                self._file_stream.seek(0)
+                file_stream.seek(header_offset)
                 break
 
-            event: bytes = self._file_stream.read(event_len)
+            event: bytes = file_stream.read(event_len)
 
             event_proto = event_pb2.Event()
             event_proto.ParseFromString(event)
@@ -77,7 +91,7 @@ class EventsFileReader:
 
             current_offset += 1 + event_len + skip_bytes
 
-            self._file_stream.seek(current_offset)
+            file_stream.seek(current_offset)
 
     @property
     def file_name(self) -> Optional[Path]:
@@ -95,6 +109,8 @@ class EventsFileReader:
 
     def open(self) -> bool:
         self._file_stream = open(self._file_name, "rb")
+        # can't always compute offsets?
+        # self.compute_offsets()
         return self.is_open()
 
     def close(self) -> bool:
@@ -111,43 +127,56 @@ class EventsFileReader:
     def seek(self, uri: Uri, frame_id: int) -> None:
         assert uri.string() in self.offsets.keys()
         assert frame_id < self.num_frames(uri)
-        self._file_stream.seek(self.offsets[uri.string()][frame_id])
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return None
+        file_stream = cast(IO, maybe_file_stream)
+        file_stream.seek(self.offsets[uri.string()][frame_id])
 
     def seek_and_read(self, uri: Uri, frame_idx: int) -> Optional[Any]:
         self.seek(uri, frame_idx)
         return self.read()
 
-    def read(self) -> Optional[Any]:
+    def read(self) -> Optional[Tuple[Any, uri_pb2.Uri]]:
         # Read the message's length as bytes and convert it to an integer
-        event_len = int.from_bytes(self._file_stream.read(1), sys.byteorder)
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return None
+        file_stream = cast(IO, maybe_file_stream)
+
+        event_len = int.from_bytes(file_stream.read(1), sys.byteorder)
         if event_len == 0:
             self.close()
             return None
 
         # Read that number of bytes as the message bytes
-        event: bytes = self._file_stream.read(event_len)
+        event: bytes = file_stream.read(event_len)
 
         event_proto = event_pb2.Event()
         event_proto.ParseFromString(event)
 
         # parse the message
         message_cls = getattr(
-            importlib.import_module(event_proto.module), event_proto.name
+            importlib.import_module(event_proto.uri.scheme), event_proto.uri.authority
         )
 
-        message: bytes = self._file_stream.read(event_proto.length_next)
+        message: bytes = file_stream.read(event_proto.payload_length)
 
         message_out = message_cls()
         message_out.ParseFromString(message)
 
-        return message_out
+        return event_proto, message_out
 
     def header(self) -> event_pb2.EventHeader:
-        self._file_stream.seek(0)
-        header_len = int.from_bytes(self._file_stream.read(1), sys.byteorder)
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return event_pb2.EventHeader()
+        file_stream = cast(IO, maybe_file_stream)
+        file_stream.seek(0)
+        header_len = int.from_bytes(file_stream.read(1), sys.byteorder)
 
         # Read that number of bytes as the message bytes
-        header: bytes = self._file_stream.read(header_len)
+        header: bytes = file_stream.read(header_len)
 
         header_proto = event_pb2.EventHeader()
         header_proto.ParseFromString(header)

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -1,6 +1,4 @@
 import importlib
-from importlib.resources import Package
-import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Tuple
@@ -56,7 +54,6 @@ class EventsFileReader:
             f"file_name: {str(self.file_name)} "
             + f"file_stream: {self._file_stream} "
             + f"is_open: {self.is_open()} "
-            + f"file_length: {self.file_length}"
         )
 
     @property

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -50,21 +50,22 @@ class EventsFileWriter:
         self._file_stream = None
         return self.is_closed()
 
-    def write(self, message: Any, uri: Optional[uri_pb2.Uri] = None) -> None:
+    def write(self, message: Any) -> None:
         maybe_file_stream = self._file_stream
         if maybe_file_stream is None:
-            return None
+            return
         file_stream = cast(IO, maybe_file_stream)
 
-        if uri is None:
-            uri = uri_pb2.Uri()
+        # create a Uri to store the descriptor of the message
+        # it comes in the form of `farm_ng.core.proto.Timestamp`
+        uri = uri_pb2.Uri(scheme=message.DESCRIPTOR.full_name)
 
         event = event_pb2.Event(
             uri=uri,
             payload_length=message.ByteSize(),
         )
 
-        event_len: bytes = event.ByteSize().to_bytes(1, sys.byteorder)
+        event_len: bytes = event.ByteSize().to_bytes(4, sys.byteorder)
 
         file_stream.write(event_len)
         file_stream.write(event.SerializeToString())

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -1,10 +1,12 @@
 import sys
 from pathlib import Path
 from typing import Any
-from typing import BinaryIO
+from typing import cast
+from typing import IO
 from typing import Optional
 
 from farm_ng.core import event_pb2
+from farm_ng.core import uri_pb2
 
 
 class EventsFileWriter:
@@ -12,10 +14,13 @@ class EventsFileWriter:
         self._file_name = file_name.absolute()
         assert Path(self._file_name.parents[0]).is_dir()
 
-        self._file_stream: Optional[BinaryIO] = None
+        self._file_stream: Optional[IO] = None
 
     def __repr__(self) -> str:
-        return f"file_name: {str(self.file_name)}\nfile_stream: {self._file_stream}\nis_open: {self.is_open}"
+        return (
+            f"file_name: {str(self.file_name)}\n"
+            f"file_stream: {self._file_stream}\nis_open: {self.is_open}"
+        )
 
     @property
     def file_name(self) -> Optional[Path]:
@@ -36,24 +41,31 @@ class EventsFileWriter:
         return self.is_open()
 
     def close(self) -> bool:
-        self._file_stream.close()
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return False
+        file_stream = cast(IO, maybe_file_stream)
+
+        file_stream.close()
         self._file_stream = None
         return self.is_closed()
 
-    def write(self, message: Any, uri: Optional[event_pb2.Uri] = None) -> None:
+    def write(self, message: Any, uri: Optional[uri_pb2.Uri] = None) -> None:
+        maybe_file_stream = self._file_stream
+        if maybe_file_stream is None:
+            return None
+        file_stream = cast(IO, maybe_file_stream)
 
         if uri is None:
-            uri = event_pb2.Uri()
+            uri = uri_pb2.Uri()
 
         event = event_pb2.Event(
-            module=str(message.__module__),
-            name=str(message.__class__.__name__),
-            length_next=message.ByteSize(),
             uri=uri,
+            payload_length=message.ByteSize(),
         )
 
         event_len: bytes = event.ByteSize().to_bytes(1, sys.byteorder)
 
-        self._file_stream.write(event_len)
-        self._file_stream.write(event.SerializeToString())
-        self._file_stream.write(message.SerializeToString())
+        file_stream.write(event_len)
+        file_stream.write(event.SerializeToString())
+        file_stream.write(message.SerializeToString())

--- a/py/farm_ng/core/stamp.py
+++ b/py/farm_ng/core/stamp.py
@@ -1,0 +1,22 @@
+import time
+from farm_ng.core.timestamp_pb2 import Timestamp
+import platform
+
+_g_host_name = platform.node()
+
+
+def set_host_name(name: str) -> None:
+    global _g_host_name
+    _g_host_name = name
+
+
+def get_host_name() -> str:
+    return _g_host_name
+
+
+def get_monotonic_now(semantics: str) -> Timestamp:
+    return Timestamp(
+        stamp=time.monotonic(),
+        clock_name=get_host_name() + "/monotonic",
+        semantics=semantics,
+    )

--- a/py/farm_ng/core/stamp.py
+++ b/py/farm_ng/core/stamp.py
@@ -1,17 +1,6 @@
 import time
 from farm_ng.core.timestamp_pb2 import Timestamp
-import platform
-
-_g_host_name = platform.node()
-
-
-def set_host_name(name: str) -> None:
-    global _g_host_name
-    _g_host_name = name
-
-
-def get_host_name() -> str:
-    return _g_host_name
+from farm_ng.core.uri import get_host_name
 
 
 def get_monotonic_now(semantics: str) -> Timestamp:

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -34,5 +34,7 @@ def uri_to_string(uri: uri_pb2.Uri) -> str:
 def string_to_uri(string: str) -> uri_pb2.Uri:
     scheme_name, remainder = string.split("://")
     remainder, query = remainder.split("?")
-    authority, path = remainder.split("/")
+    authority_path = remainder.split("/")
+    authority = authority_path[0]
+    path = "/".join(authority_path[1:])
     return uri_pb2.Uri(scheme=scheme_name, authority=authority, path=path, query=query)

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -1,17 +1,27 @@
-from farm_ng.core import uri_pb2
-from google.protobuf.message import Message
+from dataclasses import dataclass
 import platform
 
-_g_host_name = platform.node()
+from farm_ng.core import uri_pb2
+from google.protobuf.message import Message
+
+
+@dataclass
+class PlatformConfig:
+    host_name: str = platform.node()
+
+
+# https://vald-phoenix.github.io/pylint-errors/plerr/errors/variables/W0603.html
+platform_config = PlatformConfig()
 
 
 def set_host_name(name: str) -> None:
-    global _g_host_name
-    _g_host_name = name
+    # global HOST_NAME
+    # HOST_NAME = name
+    platform_config.host_name = name
 
 
 def get_host_name() -> str:
-    return _g_host_name
+    return platform_config.host_name
 
 
 def get_authority() -> str:

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -1,33 +1,38 @@
 from farm_ng.core import uri_pb2
+from google.protobuf.message import Message
+import platform
+
+_g_host_name = platform.node()
 
 
-class Uri:
-    def __init__(self, uri: uri_pb2.Uri) -> None:
-        self._uri = uri
+def set_host_name(name: str) -> None:
+    global _g_host_name
+    _g_host_name = name
 
-    def __eq__(self, other: "Uri") -> bool:
-        assert isinstance(other, Uri), f"Expected Uri type. Got: {type(other)}"
-        return self.string() == other.string()
 
-    def __repr__(self) -> str:
-        return self.string()
+def get_host_name() -> str:
+    return _g_host_name
 
-    @property
-    def proto(self) -> uri_pb2.Uri:
-        return self._uri
 
-    @classmethod
-    def empty(cls) -> "Uri":
-        return Uri(uri_pb2.Uri())
+def get_authority() -> str:
+    return get_host_name()
 
-    def string(self) -> str:
-        return f"{self.proto.scheme}://{self.proto.authority}/{self.proto.path}?{self.proto.query}"
 
-    @classmethod
-    def from_string(cls, string: str) -> "Uri":
-        scheme_name, remainder = string.split("://")
-        remainder, query = remainder.split("?")
-        authority, path = remainder.split("/")
-        return cls(
-            uri_pb2.Uri(scheme=scheme_name, authority=authority, path=path, query=query)
-        )
+def make_proto_uri(path, message: Message) -> uri_pb2.Uri:
+    return uri_pb2.Uri(
+        scheme="protobuf",
+        authority=get_authority(),
+        path=path,
+        query="type=" + message.DESCRIPTOR.full_name,
+    )
+
+
+def uri_to_string(uri: uri_pb2.Uri) -> str:
+    return f"{uri.scheme}://{uri.authority}/{uri.path}?{uri.query}"
+
+
+def string_to_uri(string: str) -> uri_pb2.Uri:
+    scheme_name, remainder = string.split("://")
+    remainder, query = remainder.split("?")
+    authority, path = remainder.split("/")
+    return uri_pb2.Uri(scheme=scheme_name, authority=authority, path=path, query=query)

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -1,8 +1,8 @@
-from farm_ng.core import event_pb2
+from farm_ng.core import uri_pb2
 
 
 class Uri:
-    def __init__(self, uri: event_pb2.Uri) -> None:
+    def __init__(self, uri: uri_pb2.Uri) -> None:
         self._uri = uri
 
     def __eq__(self, other: "Uri") -> bool:
@@ -13,17 +13,17 @@ class Uri:
         return self.string()
 
     @property
-    def proto(self) -> event_pb2.Uri:
+    def proto(self) -> uri_pb2.Uri:
         return self._uri
 
     @property
     def scheme(self) -> str:
-        scheme_value = event_pb2.UriSchemeType.DESCRIPTOR.values[self._uri.scheme]
+        scheme_value = uri_pb2.UriSchemeType.DESCRIPTOR.values[self._uri.scheme]
         return scheme_value.name.lower()
 
     @classmethod
     def empty(cls) -> "Uri":
-        return Uri(event_pb2.Uri())
+        return Uri(uri_pb2.Uri())
 
     def string(self) -> str:
         return (
@@ -41,11 +41,11 @@ class Uri:
     def from_strings(
         self, scheme_name: str, authority: str, path: str, query: str
     ) -> "Uri":
-        scheme_value = event_pb2.UriSchemeType.DESCRIPTOR.values_by_name[
+        scheme_value = uri_pb2.UriSchemeType.DESCRIPTOR.values_by_name[
             scheme_name.upper()
         ]
         return Uri(
-            event_pb2.Uri(
+            uri_pb2.Uri(
                 scheme=scheme_value.number, authority=authority, path=path, query=query
             )
         )

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -28,17 +28,6 @@ class Uri:
         scheme_name, remainder = string.split("://")
         remainder, query = remainder.split("?")
         authority, path = remainder.split("/")
-        return Uri.from_strings(scheme_name, authority, path, query)
-
-    @classmethod
-    def from_strings(
-        cls, scheme_name: str, authority: str, path: str, query: str
-    ) -> "Uri":
-        scheme_value = uri_pb2.UriSchemeType.DESCRIPTOR.values_by_name[
-            scheme_name.upper()
-        ]
-        return Uri(
-            uri_pb2.Uri(
-                scheme=scheme_value.number, authority=authority, path=path, query=query
-            )
+        return cls(
+            uri_pb2.Uri(scheme=scheme_name, authority=authority, path=path, query=query)
         )

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -16,22 +16,15 @@ class Uri:
     def proto(self) -> uri_pb2.Uri:
         return self._uri
 
-    @property
-    def scheme(self) -> str:
-        scheme_value = uri_pb2.UriSchemeType.DESCRIPTOR.values[self._uri.scheme]
-        return scheme_value.name.lower()
-
     @classmethod
     def empty(cls) -> "Uri":
         return Uri(uri_pb2.Uri())
 
     def string(self) -> str:
-        return (
-            f"{self.scheme}://{self._uri.authority}/{self._uri.path}?{self._uri.query}"
-        )
+        return f"{self.proto.scheme}://{self.proto.authority}/{self.proto.path}?{self.proto.query}"
 
     @classmethod
-    def from_string(self, string: str) -> "Uri":
+    def from_string(cls, string: str) -> "Uri":
         scheme_name, remainder = string.split("://")
         remainder, query = remainder.split("?")
         authority, path = remainder.split("/")
@@ -39,7 +32,7 @@ class Uri:
 
     @classmethod
     def from_strings(
-        self, scheme_name: str, authority: str, path: str, query: str
+        cls, scheme_name: str, authority: str, path: str, query: str
     ) -> "Uri":
         scheme_value = uri_pb2.UriSchemeType.DESCRIPTOR.values_by_name[
             scheme_name.upper()

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -25,7 +25,7 @@ setup_requires =
     grpcio-tools
 
 install_requires =
-    protobuf<4.0dev
+    protobuf
     grpcio
 
 tests_require =

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -36,7 +36,6 @@ tests_require =
 test_suite = tests
 
 packages =
-    farm_ng
     farm_ng.core
 
 [options.extras_require]

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = farm_ng_core
-version = 0.0.1-dev
+version = 0.1.0-dev
 description =
 long_description = file: README.md
 author = Farm-ng Inc.

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
-name = farm_ng
+name = farm_ng_core
 version = 0.0.1-dev
 description =
 long_description = file: README.md
 author = Farm-ng Inc.
 author_email = info@farm-ng.com
-url = https://github.com/farm-ng/amiga-dev-kit
-download_url = https://github.com/farm-ng/amiga-dev-kit
+url = https://github.com/farm-ng/farm-ng-core
+download_url = https://github.com/farm-ng/farm-ng-core
 keywords = robotics, open-source
 license_files = LICENSE
 classifiers =
@@ -37,6 +37,8 @@ test_suite = tests
 
 packages =
     farm_ng.core
+package_dir =
+    farm_ng.core = farm_ng/core
 
 [options.extras_require]
 dev =

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = farm_ng_core
+name = farm_ng
 version = 0.0.1-dev
 description =
 long_description = file: README.md

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -45,6 +45,11 @@ dev =
     pytest-mypy==0.9.1
     pre-commit==2.20.0
     mypy==0.971
+    types-protobuf
+    pylint
+    grpcio-tools
+    mypy-protobuf
+    pylint-protobuf==0.20.2
 
 [mypy]
 files = tests, examples

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = farm_ng
+name = farm_ng_core
 version = 0.0.1-dev
 description =
 long_description = file: README.md

--- a/py/setup.cfg
+++ b/py/setup.cfg
@@ -37,8 +37,6 @@ test_suite = tests
 
 packages =
     farm_ng.core
-package_dir =
-    farm_ng.core = farm_ng/core
 
 [options.extras_require]
 dev =

--- a/py/setup.py
+++ b/py/setup.py
@@ -79,5 +79,5 @@ setup(
         "develop": BuildProtosDevelop,
         "egg_info": BuildProtosEggInfo,
         "clean": CleanFilesCommand,
-    }
+    },
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -7,6 +7,8 @@ from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
+from grpc_tools import command
+
 
 class BuildProtosCommand(Command):
     user_options = []
@@ -18,12 +20,13 @@ class BuildProtosCommand(Command):
         pass
 
     def run(self):
-        from grpc_tools import command
 
         proto_files_root = Path("../protos")
         command.build_package_protos(proto_files_root)
 
         for proto_file in proto_files_root.rglob("*_pb2*.py"):
+            proto_file.rename(Path("./farm_ng/core") / proto_file.name)
+        for proto_file in proto_files_root.rglob("*_pb2*.pyi"):
             proto_file.rename(Path("./farm_ng/core") / proto_file.name)
 
 
@@ -39,6 +42,8 @@ class CleanFilesCommand(Command):
     def run(self):
         proto_files_root = Path("./farm_ng")
         for proto_file in proto_files_root.rglob("*_pb2*.py"):
+            assert proto_file.unlink() is None
+        for proto_file in proto_files_root.rglob("*_pb2*.pyi"):
             assert proto_file.unlink() is None
 
 

--- a/py/setup.py
+++ b/py/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.install import install
 
 
 class BuildProtosCommand(Command):
-    user_options = []
+    user_options = []  # type: ignore
 
     def initialize_options(self):
         pass
@@ -38,7 +38,7 @@ class BuildProtosCommand(Command):
 
 
 class CleanFilesCommand(Command):
-    user_options = []
+    user_options = []  # type: ignore
 
     def initialize_options(self):
         pass

--- a/py/setup.py
+++ b/py/setup.py
@@ -7,8 +7,6 @@ from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
-from grpc_tools import command
-
 
 class BuildProtosCommand(Command):
     user_options = []
@@ -20,6 +18,7 @@ class BuildProtosCommand(Command):
         pass
 
     def run(self):
+        from grpc_tools import command
 
         proto_files_root = Path("../protos")
         command.build_package_protos(proto_files_root)

--- a/py/setup.py
+++ b/py/setup.py
@@ -24,9 +24,17 @@ class BuildProtosCommand(Command):
         command.build_package_protos(proto_files_root)
 
         for proto_file in proto_files_root.rglob("*_pb2*.py"):
-            proto_file.rename(Path("./farm_ng/core") / proto_file.name)
+            proto_file_new = Path(*proto_file.parts[2:])
+            if not proto_file_new.exists():
+                proto_file.rename(proto_file_new)
+            if proto_file.exists():
+                proto_file.unlink()
         for proto_file in proto_files_root.rglob("*_pb2*.pyi"):
-            proto_file.rename(Path("./farm_ng/core") / proto_file.name)
+            proto_file_new = Path(*proto_file.parts[2:])
+            if not proto_file_new.exists():
+                proto_file.rename(proto_file_new)
+            if proto_file.exists():
+                proto_file.unlink()
 
 
 class CleanFilesCommand(Command):

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -1,19 +1,19 @@
 from pathlib import Path
 
 import pytest
-from farm_ng.core import event_pb2
+from farm_ng.core import uri_pb2
 from farm_ng.core.events_file_reader import EventsFileReader
 from farm_ng.core.events_file_writer import EventsFileWriter
 
 
-@pytest.fixture
-def writer(tmpdir) -> EventsFileWriter:
+@pytest.fixture(name="writer")
+def fixture_writer(tmpdir) -> EventsFileWriter:
     file_name = Path(tmpdir) / "event.log"
     return EventsFileWriter(file_name)
 
 
-@pytest.fixture
-def reader(tmpdir) -> EventsFileReader:
+@pytest.fixture(name="reader")
+def fixture_reader(tmpdir) -> EventsFileReader:
     file_name = Path(tmpdir) / "event.log"
     return EventsFileReader(file_name)
 
@@ -39,7 +39,7 @@ class TestEventsWriter:
 
     def test_write_images(self, writer: EventsFileWriter) -> None:
         assert writer.open()
-        uri = event_pb2.Uri()
+        uri = uri_pb2.Uri()
         writer.write(uri)
         assert writer.close()
 
@@ -73,11 +73,11 @@ class TestEventsReader:
     ) -> None:
         # write file
         assert writer.open()
-        uri = event_pb2.Uri()
+        uri = uri_pb2.Uri(scheme="farm_ng.core.uri_pb2", authority="Uri")
         writer.write(uri, uri)
         assert writer.close()
         # read back the data
         assert reader.open()
-        uri_out = reader.read()
+        _, uri_out = reader.read()
         assert reader.close()
         assert uri == uri_out

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -1,14 +1,15 @@
 from pathlib import Path
+from typing import List, Tuple
 
 import pytest
-from farm_ng.core import timestamp_pb2
-from farm_ng.core.events_file_reader import EventsFileReader
+from farm_ng.core import timestamp_pb2, uri_pb2, event_pb2
+from farm_ng.core.events_file_reader import EventsFileReader, parse_protobuf_descriptor
 from farm_ng.core.events_file_writer import EventsFileWriter
 from farm_ng.core.stamp import get_monotonic_now
 
 
 @pytest.fixture(name="log_file")
-def fixture_writer(tmpdir) -> Path:
+def fixture_log_file(tmpdir) -> Path:
     return Path(tmpdir) / "event.log"
 
 
@@ -21,20 +22,25 @@ class TestEventsWriter:
     def test_open_close(self, log_file: Path) -> None:
         # open the file
         writer = EventsFileWriter(log_file)
-        assert writer.open()
-        assert not writer.is_closed()
-        assert writer.is_open()
-        assert writer.file_name.name == "event.log"
-        # close the file
+        assert "event.log" in str(writer.file_name)
+        assert writer.file_length == 0
         assert writer.close()
         assert writer.is_closed()
         assert not writer.is_open()
-        assert writer.file_name == log_file
 
-    def test_write_images(self, log_file: Path) -> None:
+        # open object
+        assert writer.open()
+        assert not writer.is_closed()
+        assert writer.is_open()
+        assert writer.close()
+
+    def test_write_stamp(self, log_file: Path) -> None:
         writer = EventsFileWriter(log_file)
         assert writer.open()
         writer.write("test/uri", message=get_monotonic_now(semantics="test/monotonic"))
+        assert writer.file_length == 217
+        writer.write("test/uri", message=get_monotonic_now(semantics="test/monotonic"))
+        assert writer.file_length == 434
         assert writer.close()
 
 
@@ -49,8 +55,6 @@ class TestEventsReader:
                 path="/leading/slash",
                 message=get_monotonic_now(semantics="test/monotonic"),
             )
-        # em
-        # empty object
         with EventsFileReader(log_file) as reader:
             assert reader.is_open()
             uris = reader.uris()
@@ -59,14 +63,45 @@ class TestEventsReader:
             assert uris[0].path == "/leading/slash"
             assert uris[1].path == "hello/world"
 
-    def test_write_read(self, log_file: Path) -> None:
+    def test_open_close(self, log_file: Path) -> None:
         with EventsFileWriter(log_file) as writer:
-            for i in range(10):
+            writer.write(
+                path="hello/world",
+                message=get_monotonic_now(semantics="test/monotonic"),
+            )
+        # empty object
+        reader = EventsFileReader(log_file)
+        assert "event.log" in str(reader.file_name)
+        assert reader.file_length == 0
+        assert reader.close()
+        assert reader.is_closed()
+        assert not reader.is_open()
+        assert not reader.has_uri(uri_pb2.Uri())
+        assert reader.num_events(uri_pb2.Uri()) == 0
+
+        # open object
+        assert reader.open()
+        assert reader.file_length == 220
+        assert not reader.is_closed()
+        assert reader.is_open()
+        assert reader.close()
+
+    def test_parse_proto_descriptor(self):
+        uri = uri_pb2.Uri(
+            scheme="protobuf", path="tik/tok", query="type=farm_ng.core.proto.Timestamp"
+        )
+        name, package = parse_protobuf_descriptor(uri)
+        assert name == "Timestamp"
+        assert package == "farm_ng.core.timestamp_pb2"
+
+    def test_write_read(self, log_file: Path) -> None:
+        num_events = 10
+        with EventsFileWriter(log_file) as writer:
+            for i in range(num_events):
                 time_stamp = timestamp_pb2.Timestamp(stamp=i)
                 writer.write(path="hello", message=time_stamp)
                 writer.write(path="world", message=time_stamp)
-            print(writer.file_length)
-        # empty object
+
         with EventsFileReader(log_file) as reader:
             assert reader.is_open()
             count = 0
@@ -77,9 +112,16 @@ class TestEventsReader:
                     assert message.stamp == count
                     count += 1
 
-            uris = reader.uris()
+            # test get/has uris
+            assert not reader._event_index
+            uris: List[uri_pb2.Uri] = reader.uris()
+            assert reader._event_index
 
-            # TODO This api is likely in flux
+            assert len(reader.uris()) == 2, uris
+            assert uris[0].path == "hello"
+            assert uris[1].path == "world"
+
+            # TODO(edgar/ethan): This api is likely in flux
             # there are several ways we want to seek and
             # iterate over the reader
             #    frame order, per uri
@@ -88,18 +130,17 @@ class TestEventsReader:
             #
             # Perhaps you can just get a list of all events
             # and filter it at the user level.
-            # Then: reader.read(offset, event) will seek to and read the given event
-            for event, offset in reader.events(uri=uris[0]):
-                print(offset, event.timestamps[-1].stamp)
+            # Then: reader.read_message(event, offset) will seek to and read the given event
+            for uri in uris:
+                assert reader.has_uri(uri)
 
-            assert len(reader.uris()) == 2, uris
-            assert uris[0].path == "hello"
-            assert uris[1].path == "world"
-            assert reader.num_events(uris[0]) == 10
-            assert reader.num_events(uris[1]) == 10
-            for frame_n in range(reader.num_events(uris[0])):
-                event, offset = reader.get_event(uri=uris[0], frame_id=frame_n)
-                message = reader.read_message(event, offset)
-                assert message.stamp == frame_n
+                # test get/has events
+                events: List[Tuple[event_pb2.Event, int]] = reader.events(uri)
+                assert len(events) == reader.num_events(uri) == num_events
+
+                for frame_n in range(reader.num_events(uri)):
+                    event, offset = reader.get_event(uri, frame_n)
+                    message = reader.read_message(event, offset)
+                    assert message.stamp == frame_n
 
         assert reader.close()

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -7,27 +7,20 @@ from farm_ng.core.events_file_reader import EventsFileReader
 from farm_ng.core.events_file_writer import EventsFileWriter
 
 
-@pytest.fixture(name="writer")
-def fixture_writer(tmpdir) -> EventsFileWriter:
-    file_name = Path(tmpdir) / "event.log"
-    return EventsFileWriter(file_name)
-
-
-@pytest.fixture(name="reader")
-def fixture_reader(tmpdir) -> EventsFileReader:
-    file_name = Path(tmpdir) / "event.log"
-    return EventsFileReader(file_name)
+@pytest.fixture(name="log_file")
+def fixture_writer(tmpdir) -> Path:
+    return Path(tmpdir) / "event.log"
 
 
 class TestEventsWriter:
-    def test_smoke(self, writer: EventsFileWriter) -> None:
-        # empty object
-        assert writer.is_closed()
-        assert not writer.is_open()
-        assert writer.file_name is None
+    def test_smoke(self, log_file: Path) -> None:
+        with EventsFileWriter(log_file) as writer:
+            assert writer.is_open()
+            assert writer.file_name == log_file
 
-    def test_open_close(self, writer: EventsFileWriter) -> None:
+    def test_open_close(self, log_file: Path) -> None:
         # open the file
+        writer = EventsFileWriter(log_file)
         assert writer.open()
         assert not writer.is_closed()
         assert writer.is_open()
@@ -36,7 +29,7 @@ class TestEventsWriter:
         assert writer.close()
         assert writer.is_closed()
         assert not writer.is_open()
-        assert writer.file_name is None
+        assert writer.file_name == log_file
 
     def test_write_images(self, writer: EventsFileWriter) -> None:
         assert writer.open()

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from farm_ng.core import uri_pb2
+from farm_ng.core import timestamp_pb2
 from farm_ng.core.events_file_reader import EventsFileReader
 from farm_ng.core.events_file_writer import EventsFileWriter
 
@@ -73,11 +74,19 @@ class TestEventsReader:
     ) -> None:
         # write file
         assert writer.open()
-        uri = uri_pb2.Uri(scheme="farm_ng.core.uri_pb2", authority="Uri")
-        writer.write(uri, uri)
+        for i in range(1, 10):
+            time_stamp = timestamp_pb2.Timestamp(stamp=i)
+            writer.write(time_stamp)
         assert writer.close()
         # read back the data
         assert reader.open()
-        _, uri_out = reader.read()
+        count = 1
+        while True:
+            res = reader.read()
+            if res is None:
+                break
+            _, msg = res
+            assert msg.stamp == count
+            count += 1
+
         assert reader.close()
-        assert uri == uri_out

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -43,12 +43,22 @@ class TestEventsReader:
     def test_smoke(self, log_file: Path) -> None:
         with EventsFileWriter(log_file) as writer:
             writer.write(
-                path="hello", message=get_monotonic_now(semantics="test/monotonic")
+                path="hello/world",
+                message=get_monotonic_now(semantics="test/monotonic"),
             )
+            writer.write(
+                path="/leading/slash",
+                message=get_monotonic_now(semantics="test/monotonic"),
+            )
+        # em
         # empty object
         with EventsFileReader(log_file) as reader:
             assert reader.is_open()
-            print(reader.uris())
+            uris = reader.uris()
+            print(uris)
+            # note lexographic ordering of paths.
+            assert uris[0].path == "/leading/slash"
+            assert uris[1].path == "hello/world"
 
     def test_write_read(self, log_file: Path) -> None:
         with EventsFileWriter(log_file) as writer:

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -38,9 +38,8 @@ class TestEventsWriter:
         writer = EventsFileWriter(log_file)
         assert writer.open()
         writer.write("test/uri", message=get_monotonic_now(semantics="test/monotonic"))
-        assert writer.file_length == 217
         writer.write("test/uri", message=get_monotonic_now(semantics="test/monotonic"))
-        assert writer.file_length == 434
+        assert writer.file_length > 0
         assert writer.close()
 
 
@@ -81,7 +80,7 @@ class TestEventsReader:
 
         # open object
         assert reader.open()
-        assert reader.file_length == 220
+        assert reader.file_length > 0
         assert not reader.is_closed()
         assert reader.is_open()
         assert reader.close()

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -36,7 +36,6 @@ class TestEventsWriter:
         assert writer.open()
         writer.write("test/uri", message=get_monotonic_now(semantics="test/monotonic"))
         assert writer.close()
-        assert writer.file_length == 181, writer.file_length
 
 
 class TestEventsReader:

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -70,11 +70,6 @@ class TestEventsReader:
         # empty object
         with EventsFileReader(log_file) as reader:
             assert reader.is_open()
-            uris = reader.uris()
-
-            assert len(reader.uris()) == 2, uris
-            assert uris[0].path == "hello"
-            assert uris[1].path == "world"
             count = 0
             for event, message in reader.read_messages():
                 if event.uri.path == "hello":
@@ -82,5 +77,17 @@ class TestEventsReader:
                 elif event.uri.path == "world":
                     assert message.stamp == count
                     count += 1
+
+            uris = reader.uris()
+
+            assert len(reader.uris()) == 2, uris
+            assert uris[0].path == "hello"
+            assert uris[1].path == "world"
+            assert reader.num_frames(uris[0]) == 10
+            assert reader.num_frames(uris[1]) == 10
+            for frame_n in range(reader.num_frames(uris[0])):
+                reader.seek(uri=uris[0], frame_id=frame_n)
+                event, message = reader.read()
+                assert message.stamp == frame_n
 
         assert reader.close()

--- a/py/tests/tests/test_core.py
+++ b/py/tests/tests/test_core.py
@@ -80,14 +80,27 @@ class TestEventsReader:
 
             uris = reader.uris()
 
+            # TODO This api is likely in flux
+            # there are several ways we want to seek and
+            # iterate over the reader
+            #    frame order, per uri
+            #    time order, per uri
+            #    time order, all uris
+            #
+            # Perhaps you can just get a list of all events
+            # and filter it at the user level.
+            # Then: reader.read(offset, event) will seek to and read the given event
+            for event, offset in reader.events(uri=uris[0]):
+                print(offset, event.timestamps[-1].stamp)
+
             assert len(reader.uris()) == 2, uris
             assert uris[0].path == "hello"
             assert uris[1].path == "world"
-            assert reader.num_frames(uris[0]) == 10
-            assert reader.num_frames(uris[1]) == 10
-            for frame_n in range(reader.num_frames(uris[0])):
-                reader.seek(uri=uris[0], frame_id=frame_n)
-                event, message = reader.read()
+            assert reader.num_events(uris[0]) == 10
+            assert reader.num_events(uris[1]) == 10
+            for frame_n in range(reader.num_events(uris[0])):
+                event, offset = reader.get_event(uri=uris[0], frame_id=frame_n)
+                message = reader.read_message(event, offset)
                 assert message.stamp == frame_n
 
         assert reader.close()

--- a/py/tests/tests/test_package.py
+++ b/py/tests/tests/test_package.py
@@ -2,5 +2,5 @@ import farm_ng
 
 
 def test_import() -> None:
-    assert farm_ng.__version__ is not None
     assert farm_ng.core is not None
+    assert farm_ng.core.__version__ is not None

--- a/py/tests/tests/test_stamp.py
+++ b/py/tests/tests/test_stamp.py
@@ -1,0 +1,10 @@
+from farm_ng.core import timestamp_pb2
+from farm_ng.core.stamp import get_monotonic_now
+
+
+def test_monotonic():
+    stamp = get_monotonic_now(semantics="test/monotonic")
+    assert isinstance(stamp, timestamp_pb2.Timestamp)
+    assert isinstance(stamp.stamp, float)
+    assert "monotonic" in stamp.clock_name
+    assert stamp.semantics == "test/monotonic"

--- a/py/tests/tests/test_uri.py
+++ b/py/tests/tests/test_uri.py
@@ -1,0 +1,20 @@
+from farm_ng.core import uri_pb2
+from farm_ng.core import timestamp_pb2
+from farm_ng.core.uri import make_proto_uri, uri_to_string, string_to_uri
+
+
+def test_make_proto():
+    stamp = timestamp_pb2.Timestamp(
+        stamp=1.2, clock_name="clock0", semantics="test/proto"
+    )
+    uri: uri_pb2.Uri = make_proto_uri("tik/tok", stamp)
+    assert uri.scheme == "protobuf"
+    assert uri.path == "tik/tok"
+    assert uri.query == "type=farm_ng.core.proto.Timestamp"
+
+    uri_str: str = uri_to_string(uri)
+    assert "protobuf://" in uri_str
+    assert "/tik/tok?type=farm_ng.core.proto.Timestamp" in uri_str
+
+    uri_out: uri_pb2.Uri = string_to_uri(uri_str)
+    assert uri == uri_out

--- a/super_project/CMakeLists.txt
+++ b/super_project/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   farm_ng_cmake
   GIT_REPOSITORY https://github.com/farm-ng/farm-ng-cmake.git
-  GIT_TAG 91e279de02ef3ca65c2dab17bf772ea31eb91de2
+  GIT_TAG v0.1.1
 )
 
 FetchContent_MakeAvailable(farm_ng_cmake)


### PR DESCRIPTION
replacement of https://github.com/farm-ng/farm-ng-core/pull/16

- imports reader/writer code from https://github.com/farm-ng/amiga-dev-kit/tree/main/brain/farm_ng/core so that we can invert import chain
- slightly change the reader/writer to adjust to the new event file definition

**TODO**

- [ ] pyliny/mypy don't recognise well the generated proto stubs 