### PR TITLE
Protobuf install in python.

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      working-directory: py
       run: pip3 install -e .[dev]
     - name: Run Tests
       working-directory: py

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -24,5 +24,4 @@ jobs:
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run Tests
-      working-directory: py
-      run: pytest -v tests/ --mypy
+      run: pytest -v py/tests/ --mypy

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 venv
 .pytest_cache
+.eggs

--- a/py/.gitignore
+++ b/py/.gitignore
@@ -3,3 +3,4 @@
 *build*
 *pycache*
 *pb2*
+*proto*

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
     pylint-protobuf==0.20.2
 
 [mypy]
-files = tests, examples
+files = py/farm_ng, py/tests, py/examples
 ignore_missing_imports = True
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
-    License :: Other/Proprietary License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Topic :: Software Development
@@ -35,6 +35,8 @@ tests_require =
     pytest-mypy
 test_suite = tests
 
+package_dir =
+    = py
 packages =
     farm_ng.core
 
@@ -54,3 +56,7 @@ dev =
 [mypy]
 files = tests, examples
 ignore_missing_imports = True
+
+[options.package_data]
+farm_ng.core =
+    *.proto


### PR DESCRIPTION
This results in the protobuf definitions being installed along side the python files, 

```
venv/lib/python3.8/site-packages/farm_ng/core/uri_pb2_grpc.py
venv/lib/python3.8/site-packages/farm_ng/core/uri_pb2.py
venv/lib/python3.8/site-packages/farm_ng/core/uri.proto
venv/lib/python3.8/site-packages/farm_ng/core/uri.py
```