### PR TITLE
Add log level filtering and log header formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
   build:

--- a/cpp/farm_ng/core/enum/CMakeLists.txt
+++ b/cpp/farm_ng/core/enum/CMakeLists.txt
@@ -1,10 +1,10 @@
 #[[
 farm_ng_core_enum
 
-Set of macros for compile-time enum introspection / autogeneration of auxilary
+Set of macros for compile-time enum introspection / autogeneration of auxiliary
 helper functions.
 
-Depends on farm_ng_core_logging.
+Depends on third_party/farm_pp.
 
 ]]
 farm_ng_add_library(farm_ng_core_enum

--- a/cpp/farm_ng/core/enum/CMakeLists.txt
+++ b/cpp/farm_ng/core/enum/CMakeLists.txt
@@ -23,7 +23,7 @@ farm_ng_add_library(farm_ng_core_enum
     impl/enum_flag_details.h
 )
 
-target_link_libraries(farm_ng_core_enum INTERFACE farm_ng_core_logging)
+target_link_libraries(farm_ng_core_enum INTERFACE farm_ng_core::farm_pp)
 
 set(FARM_NG_ENUM_TESTS
       enum

--- a/cpp/farm_ng/core/enum/impl/enum_details.h
+++ b/cpp/farm_ng/core/enum/impl/enum_details.h
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include "farm_ng/core/logging/logger.h"
-
 #include <farm_pp/preprocessor/comparison/equal.hpp>
 #include <farm_pp/preprocessor/control/if.hpp>
 #include <farm_pp/preprocessor/punctuation/remove_parens.hpp>
@@ -213,9 +211,7 @@
           FARM_ENUM_DETAILS_TO_SEQ_OF_TUPLES(                                  \
               FARM_ENUM_DETAILS_GET_VARS(__VA_ARGS__)))                        \
     }                                                                          \
-    FARM_PANIC(                                                                \
-        FARM_PP_STRINGIZE(NAME) " does contain invalid value: {}",             \
-        FARM_ENUM_DETAILS_GET_INT_TYPE(__VA_ARGS__)(value));                   \
+    std::abort();                                                              \
   }                                                                            \
                                                                                \
   [[maybe_unused]] inline std::string_view constexpr toStringView(             \
@@ -227,9 +223,7 @@
           FARM_ENUM_DETAILS_TO_SEQ_OF_TUPLES(                                  \
               FARM_ENUM_DETAILS_GET_VARS(__VA_ARGS__)))                        \
     }                                                                          \
-    FARM_PANIC(                                                                \
-        FARM_PP_STRINGIZE(NAME) " does contain invalid value: {}",             \
-        FARM_ENUM_DETAILS_GET_INT_TYPE(__VA_ARGS__)(value));                   \
+    std::abort();                                                              \
   }                                                                            \
                                                                                \
   [[maybe_unused]] inline std::string toPretty(NAME##Impl value) {             \
@@ -240,9 +234,7 @@
           FARM_ENUM_DETAILS_TO_SEQ_OF_TUPLES(                                  \
               FARM_ENUM_DETAILS_GET_VARS(__VA_ARGS__)))                        \
     }                                                                          \
-    FARM_PANIC(                                                                \
-        FARM_PP_STRINGIZE(NAME) " does contain invalid value: {}",             \
-        FARM_ENUM_DETAILS_GET_INT_TYPE(__VA_ARGS__)(value));                   \
+    std::abort();                                                              \
   }                                                                            \
                                                                                \
   [[maybe_unused]] [[nodiscard]] inline bool trySetFromString(                 \
@@ -301,9 +293,7 @@
           FARM_ENUM_DETAILS_TO_SEQ_OF_TUPLES(                                  \
               FARM_ENUM_DETAILS_GET_VARS(__VA_ARGS__)))                        \
     }                                                                          \
-    FARM_PANIC(                                                                \
-        FARM_PP_STRINGIZE(NAME) " does contain invalid value: {}",             \
-        FARM_ENUM_DETAILS_GET_INT_TYPE(__VA_ARGS__)(value));                   \
+    std::abort();                                                              \
   }                                                                            \
                                                                                \
   [[maybe_unused]] [[nodiscard]] inline std::string_view getTypeName(          \

--- a/cpp/farm_ng/core/logging/CMakeLists.txt
+++ b/cpp/farm_ng/core/logging/CMakeLists.txt
@@ -3,8 +3,8 @@ farm_ng_core_logging
 
 Console logging, string format and CHECK macros.
 
-No dependency, but libfmt, expected (both part of future c++ standards) and
-thirdparty/farm_pp.
+Depends on libfmt, expected (both part of future c++ standards),
+thirdparty/farm_pp, and farm_ng_core_enum.
 
 ]]
 farm_ng_add_library(farm_ng_core_logging
@@ -24,6 +24,7 @@ farm_ng_add_library(farm_ng_core_logging
 )
 
 target_link_libraries(farm_ng_core_logging PUBLIC
+  farm_ng_core_enum
   farm_ng_core::farm_pp
   fmt::fmt
   pthread

--- a/cpp/farm_ng/core/logging/CMakeLists.txt
+++ b/cpp/farm_ng/core/logging/CMakeLists.txt
@@ -19,6 +19,7 @@ farm_ng_add_library(farm_ng_core_logging
   SOURCES
     format.cpp
     expected.cpp
+    logger.cpp
     backtrace.cpp
 )
 

--- a/cpp/farm_ng/core/logging/logger.cpp
+++ b/cpp/farm_ng/core/logging/logger.cpp
@@ -19,24 +19,9 @@
 namespace farm_ng {
 
 std::string stringFromLogLevel(LogLevel level) {
-  switch (level) {
-    case LogLevel::trace:
-      return "TRACE";
-    case LogLevel::debug:
-      return "DEBUG";
-    case LogLevel::info:
-      return "INFO";
-    case LogLevel::warning:
-      return "WARN";
-    case LogLevel::error:
-      return "ERROR";
-    case LogLevel::critical:
-      return "CRITICAL";
-    case LogLevel::off:
-      return "OFF";
-    default:
-      return "";
-  }
+  auto str = toString(level);
+  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+  return str;
 }
 
 void StreamLogger::setHeaderFormat(std::string const& str) {

--- a/cpp/farm_ng/core/logging/logger.cpp
+++ b/cpp/farm_ng/core/logging/logger.cpp
@@ -1,0 +1,78 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "farm_ng/core/logging/logger.h"
+
+namespace farm_ng {
+
+namespace details {
+std::string stringFromLogLevel(LogLevel level) {
+  switch (level) {
+    case LogLevel::trace:
+      return "TRACE";
+    case LogLevel::debug:
+      return "DEBUG";
+    case LogLevel::info:
+      return "INFO";
+    case LogLevel::warning:
+      return "WARN";
+    case LogLevel::error:
+      return "ERROR";
+    case LogLevel::critical:
+      return "CRITICAL";
+    case LogLevel::off:
+      return "OFF";
+    default:
+      return "";
+  }
+}
+}  // namespace details
+
+void StreamLogger::setHeaderFormat(std::string const& str) {
+  header_format_ = str;
+}
+std::string StreamLogger::getHeaderFormat() const { return header_format_; }
+
+void StreamLogger::setLogLevel(LogLevel level) { log_level_ = level; }
+
+void StreamLogger::log(
+    LogLevel log_level,
+    std::string const& header,
+    std::string const& file,
+    int line,
+    std::string const& function) {
+  if (log_level_ <= log_level) {
+    writeHeader(log_level, header, file, line, function);
+    flush();
+  }
+}
+
+void StreamLogger::writeHeader(
+    LogLevel log_level,
+    std::string const& header_text,
+    std::string const& file,
+    int line,
+    std::string const& function) {
+  write(FARM_FORMAT(
+      header_format_,
+      fmt::arg("level", details::stringFromLogLevel(log_level)),
+      fmt::arg("text", header_text),
+      fmt::arg("file", file),
+      fmt::arg("line", line),
+      fmt::arg("function", function)));
+}
+void StreamLogger::write(std::string const& str) { std::cerr << str; }
+void StreamLogger::flush() { std::cerr << std::endl; }
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/logging/logger.cpp
+++ b/cpp/farm_ng/core/logging/logger.cpp
@@ -14,9 +14,10 @@
 
 #include "farm_ng/core/logging/logger.h"
 
+#include <fmt/chrono.h>
+
 namespace farm_ng {
 
-namespace details {
 std::string stringFromLogLevel(LogLevel level) {
   switch (level) {
     case LogLevel::trace:
@@ -37,7 +38,6 @@ std::string stringFromLogLevel(LogLevel level) {
       return "";
   }
 }
-}  // namespace details
 
 void StreamLogger::setHeaderFormat(std::string const& str) {
   header_format_ = str;
@@ -45,6 +45,7 @@ void StreamLogger::setHeaderFormat(std::string const& str) {
 std::string StreamLogger::getHeaderFormat() const { return header_format_; }
 
 void StreamLogger::setLogLevel(LogLevel level) { log_level_ = level; }
+LogLevel StreamLogger::getLogLevel() { return log_level_; }
 
 void StreamLogger::log(
     LogLevel log_level,
@@ -64,9 +65,16 @@ void StreamLogger::writeHeader(
     std::string const& file,
     int line,
     std::string const& function) {
+  auto const now = std::chrono::system_clock::now();
+  auto const millis = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          now.time_since_epoch())
+                          .count() %
+                      1000;
   write(FARM_FORMAT(
       header_format_,
-      fmt::arg("level", details::stringFromLogLevel(log_level)),
+      fmt::arg("time_ms", millis),
+      fmt::arg("time", now),
+      fmt::arg("level", stringFromLogLevel(log_level)),
       fmt::arg("text", header_text),
       fmt::arg("file", file),
       fmt::arg("line", line),

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "farm_ng/core/enum/enum.h"
 #include "farm_ng/core/logging/format.h"
 
 #include <farm_pp/preprocessor/comma.hpp>
@@ -31,7 +32,7 @@
 
 // Define FARM_LOG_LEVEL to set the compile-time log level
 #ifndef FARM_LOG_LEVEL
-#define FARM_LOG_LEVEL FARM_LEVEL_INFO
+#define FARM_LOG_LEVEL FARM_LEVEL_DEBUG
 #endif
 
 namespace farm_ng {
@@ -46,22 +47,21 @@ enum class LogLevel : int {
   n_levels
 };
 
-namespace details {
-
 std::string stringFromLogLevel(LogLevel level);
-
-}  // namespace details
 
 // A logger that writes to std::cerr
 class StreamLogger {
  public:
   // The header format is a {fmt}-style format string that may include the
-  //  named arguments {level}, {text}, {file}, {line}, {function}, {timestamp}.
+  //  named arguments {level}, {text}, {file}, {line}, {function}, {time},
+  //  {time_ms}.
   void setHeaderFormat(std::string const& str);
   std::string getHeaderFormat() const;
 
   // Set the runtime log level
   void setLogLevel(LogLevel level);
+
+  LogLevel getLogLevel();
 
   void log(
       LogLevel log_level,
@@ -100,7 +100,7 @@ class StreamLogger {
   LogLevel log_level_ = LogLevel(FARM_LOG_LEVEL);
 };
 
-static StreamLogger& defaultLogger() {
+inline StreamLogger& defaultLogger() {
   static StreamLogger logger;
   return logger;
 }

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -32,7 +32,7 @@
 
 // Define FARM_LOG_LEVEL to set the compile-time log level
 #ifndef FARM_LOG_LEVEL
-#define FARM_LOG_LEVEL FARM_LEVEL_DEBUG
+#define FARM_LOG_LEVEL FARM_LEVEL_INFO
 #endif
 
 namespace farm_ng {

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -36,16 +36,7 @@
 #endif
 
 namespace farm_ng {
-enum class LogLevel : int {
-  trace = FARM_LEVEL_TRACE,
-  debug = FARM_LEVEL_DEBUG,
-  info = FARM_LEVEL_INFO,
-  warning = FARM_LEVEL_WARN,
-  error = FARM_LEVEL_ERROR,
-  critical = FARM_LEVEL_CRITICAL,
-  off = FARM_LEVEL_OFF,
-  n_levels
-};
+FARM_ENUM(LogLevel, int, (trace, debug, info, warning, error, critical, off));
 
 std::string stringFromLogLevel(LogLevel level);
 

--- a/cpp/farm_ng/core/logging/logger_test.cpp
+++ b/cpp/farm_ng/core/logging/logger_test.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-// Uncomment to see the effect of compile-time log levels
+// Change FARM_LOG_LEVEL define to see the effect of compile-time log levels
 // #define FARM_LOG_LEVEL FARM_LEVEL_TRACE
+#define FARM_LOG_LEVEL FARM_LEVEL_DEBUG
 
 #include "farm_ng/core/logging/logger.h"
 

--- a/cpp/farm_ng/core/logging/logger_test.cpp
+++ b/cpp/farm_ng/core/logging/logger_test.cpp
@@ -45,6 +45,15 @@ void expectNotContains(std::string const& str, std::regex const& regex) {
   EXPECT_FALSE(std::regex_search(str, regex)) << str;
 }
 
+void expectContainsIf(
+    bool condition, std::string const& str, std::regex const& regex) {
+  if (condition) {
+    expectContains(str, regex);
+  } else {
+    expectNotContains(str, regex);
+  }
+}
+
 TEST(logger, default_log_level) {
   CaptureStdErr capture;
   FARM_CRITICAL("0");
@@ -57,13 +66,16 @@ TEST(logger, default_log_level) {
   expectContains(capture.buffer(), std::regex{R"(\[FARM ERROR in.*1)"});
   expectContains(capture.buffer(), std::regex{R"(\[FARM WARN in.*2)"});
   expectContains(capture.buffer(), std::regex{R"(\[FARM INFO in.*34)"});
-  expectContains(capture.buffer(), std::regex{R"(\[FARM DEBUG in.*5)"});
 
-#if FARM_LOG_LEVEL == FARM_LEVEL_TRACE
-  expectContains(capture.buffer(), std::regex{R"(\[FARM TRACE in.*6)"});
-#else
-  expectNotContains(capture.buffer(), std::regex{R"(\[FARM TRACE in.*6)"});
-#endif
+  expectContainsIf(
+      FARM_LOG_LEVEL <= FARM_LEVEL_DEBUG,
+      capture.buffer(),
+      std::regex{R"(\[FARM DEBUG in.*5)"});
+
+  expectContainsIf(
+      FARM_LOG_LEVEL <= FARM_LEVEL_TRACE,
+      capture.buffer(),
+      std::regex{R"(\[FARM TRACE in.*6)"});
 }
 
 TEST(logger, runtime_log_level) {
@@ -85,9 +97,15 @@ TEST(logger, runtime_log_level) {
   expectContains(capture.buffer(), std::regex{R"(\[FARM INFO in.*34)"});
   expectContains(capture.buffer(), std::regex{R"(\[FARM DEBUG in.*5)"});
 
-#if FARM_LOG_LEVEL == FARM_LEVEL_TRACE
-  expectContains(capture.buffer(), std::regex{R"(\[FARM TRACE in.*6)"});
-#endif
+  expectContainsIf(
+      FARM_LOG_LEVEL <= FARM_LEVEL_DEBUG,
+      capture.buffer(),
+      std::regex{R"(\[FARM DEBUG in.*5)"});
+
+  expectContainsIf(
+      FARM_LOG_LEVEL <= FARM_LEVEL_TRACE,
+      capture.buffer(),
+      std::regex{R"(\[FARM TRACE in.*6)"});
 
   // Revert
   //

--- a/cpp/farm_ng/core/logging/logger_test.cpp
+++ b/cpp/farm_ng/core/logging/logger_test.cpp
@@ -18,7 +18,16 @@
 
 #include <optional>
 
-TEST(logger, unit) {
+TEST(logger_v2, smoke) {
+  std::cerr << "hello" << std::endl;
+  FARM_WARN_V2("foo: {}", 42);
+  FARM_DEBUG_V2("bar: {}", 42);
+  FARM_ERROR_V2("baz: {}", 42);
+  farm_ng::DefaultLogger().setHeaderFormat("{level}: ");
+  FARM_WARN_V2("{}", 1);
+}
+
+TEST(logger, DISABLED_unit) {
   FARM_ASSERT_NEAR(1.0, 1.01, 0.03);
   ASSERT_DEATH({ FARM_ASSERT_NEAR(1.0, 1.1, 0.05); }, "ASSERT_NEAR");
 


### PR DESCRIPTION
- Adds support for compile-time and run-time log level filtering.
- Adds support for custom header formatting.
- Adds additional log levels. In general the API tries to align with popular log frameworks like [spdlog](https://github.com/gabime/spdlog).

The log output with the default settings should be the same, or very close to the same, as the current behavior.

I'd like to deprecate `FARM_IMPL_LOG_HEADER` (currently Sophus image_types.h calls directly) and possibly `FARM_PRINTLN`.

In the future a third-party framework like spdlog could offer some compelling features like registering a custom sink that sends text logs to both `stderr` and a binary event log.   

cc: @ethanrublee 