### PR TITLE
Remove #define in logger_test

### DIFF
--- a/cpp/farm_ng/core/logging/logger_test.cpp
+++ b/cpp/farm_ng/core/logging/logger_test.cpp
@@ -14,7 +14,6 @@
 
 // Change FARM_LOG_LEVEL define to see the effect of compile-time log levels
 // #define FARM_LOG_LEVEL FARM_LEVEL_TRACE
-#define FARM_LOG_LEVEL FARM_LEVEL_DEBUG
 
 #include "farm_ng/core/logging/logger.h"
 


### PR DESCRIPTION
This causes preprocessor multiple definition errors if it's included in a parent project that defines FARM_LOG_LEVEL globally.

We can remove, or put inside a `#ifndef`. 
I admit the correct way to do this is to build the same test with multiple build configurations and see all configurations pass. 