### PR TITLE
fix: TRY macro, do not evalute expression twice

### DIFF
--- a/cpp/farm_ng/core/logging/expected.h
+++ b/cpp/farm_ng/core/logging/expected.h
@@ -74,10 +74,10 @@ struct UnwrapImpl<tl::expected<TT, TE>> {
 #define FARM_UNEXPECTED(cstr, ...) \
   ::tl::make_unexpected(FARM_ERROR_REPORT(cstr, ##__VA_ARGS__))
 
-/// Assigns `*expected_val` to `var` of `Type`, but returns error if there is
+/// Assigns `*expression` to `var` of `Type`, but returns error if there is
 /// one.
-#define FARM_TRY(Type, var, expected_val)             \
-  auto maybe##var = (expected_val);                   \
+#define FARM_TRY(Type, var, expression)               \
+  auto maybe##var = (expression);                     \
   if (!maybe##var) {                                  \
     return ::tl::make_unexpected(maybe##var.error()); \
   }                                                   \

--- a/cpp/farm_ng/core/logging/expected.h
+++ b/cpp/farm_ng/core/logging/expected.h
@@ -74,12 +74,14 @@ struct UnwrapImpl<tl::expected<TT, TE>> {
 #define FARM_UNEXPECTED(cstr, ...) \
   ::tl::make_unexpected(FARM_ERROR_REPORT(cstr, ##__VA_ARGS__))
 
-/// Assigns `*expected_val` to `Type_val`, but returns error if there is one.
-#define FARM_TRY(Type_val, expected_val)                \
-  if (!expected_val) {                                  \
-    return ::tl::make_unexpected(expected_val.error()); \
-  }                                                     \
-  Type_val = ::std::move(*expected_val)
+/// Assigns `*expected_val` to `var` of `Type`, but returns error if there is
+/// one.
+#define FARM_TRY_ASSIGN(Type, var, expected_val)      \
+  auto maybe##var = (expected_val);                   \
+  if (!maybe##var) {                                  \
+    return ::tl::make_unexpected(maybe##var.error()); \
+  }                                                   \
+  Type var = ::std::move(*maybe##var);
 
 #define FARM_ASSERT_OR_ERROR(condition, ...)                             \
   if (!(condition)) {                                                    \

--- a/cpp/farm_ng/core/logging/expected.h
+++ b/cpp/farm_ng/core/logging/expected.h
@@ -76,7 +76,7 @@ struct UnwrapImpl<tl::expected<TT, TE>> {
 
 /// Assigns `*expected_val` to `var` of `Type`, but returns error if there is
 /// one.
-#define FARM_TRY_ASSIGN(Type, var, expected_val)      \
+#define FARM_TRY(Type, var, expected_val)             \
   auto maybe##var = (expected_val);                   \
   if (!maybe##var) {                                  \
     return ::tl::make_unexpected(maybe##var.error()); \

--- a/cpp/farm_ng/core/logging/expected_test.cpp
+++ b/cpp/farm_ng/core/logging/expected_test.cpp
@@ -45,7 +45,7 @@ auto makeA(bool a_error) -> Expected<A> {
 }
 
 auto makeAb(bool a_error, bool b_error) -> Expected<Ab> {
-  FARM_TRY_ASSIGN(A, a, makeA(a_error));
+  FARM_TRY(A, a, makeA(a_error));
 
   if (b_error) {
     return FARM_UNEXPECTED("b - {}", "error");
@@ -57,7 +57,7 @@ auto makeAb(bool a_error, bool b_error) -> Expected<Ab> {
 }
 
 auto makeAbc(bool a_error, bool b_error, bool c_error) -> Expected<Abc> {
-  FARM_TRY_ASSIGN(Ab, ab, makeAb(a_error, b_error));
+  FARM_TRY(Ab, ab, makeAb(a_error, b_error));
 
   if (c_error) {
     return FARM_UNEXPECTED("c - error - {}", 42);
@@ -96,8 +96,8 @@ auto makeAbcAtOnce(bool a_error, bool b_error, bool c_error) -> Expected<Abc> {
 }
 
 auto sum(Expected<A> maybe_left, Expected<A> maybe_right) -> Expected<A> {
-  FARM_TRY_ASSIGN(A, lhs, maybe_left);
-  FARM_TRY_ASSIGN(A, rhs, maybe_right);
+  FARM_TRY(A, lhs, maybe_left);
+  FARM_TRY(A, rhs, maybe_right);
 
   A s;
   s.a = lhs.a + rhs.a;

--- a/cpp/farm_ng/core/logging/expected_test.cpp
+++ b/cpp/farm_ng/core/logging/expected_test.cpp
@@ -45,7 +45,7 @@ auto makeA(bool a_error) -> Expected<A> {
 }
 
 auto makeAb(bool a_error, bool b_error) -> Expected<Ab> {
-  FARM_TRY(A a, makeA(a_error));
+  FARM_TRY_ASSIGN(A, a, makeA(a_error));
 
   if (b_error) {
     return FARM_UNEXPECTED("b - {}", "error");
@@ -57,7 +57,7 @@ auto makeAb(bool a_error, bool b_error) -> Expected<Ab> {
 }
 
 auto makeAbc(bool a_error, bool b_error, bool c_error) -> Expected<Abc> {
-  FARM_TRY(Ab ab, makeAb(a_error, b_error));
+  FARM_TRY_ASSIGN(Ab, ab, makeAb(a_error, b_error));
 
   if (c_error) {
     return FARM_UNEXPECTED("c - error - {}", 42);
@@ -96,8 +96,8 @@ auto makeAbcAtOnce(bool a_error, bool b_error, bool c_error) -> Expected<Abc> {
 }
 
 auto sum(Expected<A> maybe_left, Expected<A> maybe_right) -> Expected<A> {
-  FARM_TRY(A lhs, maybe_left);
-  FARM_TRY(A rhs, maybe_right);
+  FARM_TRY_ASSIGN(A, lhs, maybe_left);
+  FARM_TRY_ASSIGN(A, rhs, maybe_right);
 
   A s;
   s.a = lhs.a + rhs.a;

--- a/cpp/farm_ng/core/prototools/proto_reader_writer.h
+++ b/cpp/farm_ng/core/prototools/proto_reader_writer.h
@@ -39,7 +39,7 @@ Expected<std::string> readJsonStringFromJsonFile(
 template <class TProtobufT>
 Expected<TProtobufT> readProtobufFromJsonFile(
     std::filesystem::path const& path) {
-  FARM_TRY(std::string json_string, readJsonStringFromJsonFile(path));
+  FARM_TRY_ASSIGN(std::string, json_string, readJsonStringFromJsonFile(path));
   TProtobufT message;
   google::protobuf::util::JsonParseOptions parse_options;  // default
   auto status = google::protobuf::util::JsonStringToMessage(
@@ -57,7 +57,7 @@ template <class TProtobufT>
 Expected<TProtobufT> readProtobufFromBinaryFile(
     std::filesystem::path const& path) {
   TProtobufT message;
-  FARM_TRY(std::string bytes, readBytesFromBinaryFile(path));
+  FARM_TRY_ASSIGN(std::string, bytes, readBytesFromBinaryFile(path));
   if (message.ParseFromString(bytes)) {
     return FARM_UNEXPECTED("Failed to parse {}", path.string());
   }

--- a/cpp/farm_ng/core/prototools/proto_reader_writer.h
+++ b/cpp/farm_ng/core/prototools/proto_reader_writer.h
@@ -39,7 +39,7 @@ Expected<std::string> readJsonStringFromJsonFile(
 template <class TProtobufT>
 Expected<TProtobufT> readProtobufFromJsonFile(
     std::filesystem::path const& path) {
-  FARM_TRY_ASSIGN(std::string, json_string, readJsonStringFromJsonFile(path));
+  FARM_TRY(std::string, json_string, readJsonStringFromJsonFile(path));
   TProtobufT message;
   google::protobuf::util::JsonParseOptions parse_options;  // default
   auto status = google::protobuf::util::JsonStringToMessage(
@@ -57,7 +57,7 @@ template <class TProtobufT>
 Expected<TProtobufT> readProtobufFromBinaryFile(
     std::filesystem::path const& path) {
   TProtobufT message;
-  FARM_TRY_ASSIGN(std::string, bytes, readBytesFromBinaryFile(path));
+  FARM_TRY(std::string, bytes, readBytesFromBinaryFile(path));
   if (message.ParseFromString(bytes)) {
     return FARM_UNEXPECTED("Failed to parse {}", path.string());
   }


### PR DESCRIPTION
**Problem:**

The current FARM_TRY is broken since it will evaluate the input expression ``expected_val`` twice. This is problematic if ``expected_val`` is a function call with is either costly or has a side-effect.

***~~Minor Problem:~~***

~~FARM_TRY is too generic of a name for this specific macro.~~

**Solution**:

```FARM_TRY(Type, var, expression)```

- evaluate expression once and assign to temporary variable
- give the temporary variable a unique name (based on the name of ``var``) so there won't be any name classes  when there a multiple FARM_TRY in scope.

***Alternatives:***
 - remove this macro
 - figure out a way to have the temporary variable in a local scope. This is tricky since ``Type var`` needs to be in the outer scope, and we do not want to restrict ``Type`` to being default constructable.