### PR TITLE
Revert "feat: print error on assert when there is an expected.error"

### DIFF
--- a/cpp/farm_ng/core/logging/expected.h
+++ b/cpp/farm_ng/core/logging/expected.h
@@ -83,7 +83,7 @@ struct UnwrapImpl<tl::expected<TT, TE>> {
   }                                                   \
   Type var = ::std::move(*maybe##var);
 
-#define FARM_TRY_ASSERT(condition, ...)                                  \
+#define FARM_ASSERT_OR_ERROR(condition, ...)                             \
   if (!(condition)) {                                                    \
     return FARM_UNEXPECTED(                                              \
         "bool({}) not true.\n{}", #condition, FARM_FORMAT(__VA_ARGS__)); \
@@ -103,32 +103,4 @@ Expected<TT> fromOptional(std::optional<TT> optional) {
                   : FARM_UNEXPECTED("std::nullopt");
 }
 
-namespace detail {
-
-template <class TT>
-struct AssertTrue<Expected<TT>> {
-  static void impl(
-      Expected<TT> const& condition,
-      std::string const& condition_str,
-      std::string const& file,
-      int line,
-      std::string const& func,
-      std::string const& str) {
-    if (!condition) {
-      farm_ng::defaultLogger().log(
-          farm_ng::LogLevel::critical,
-          FARM_FORMAT(
-              "PANIC: ASSERT failed\n Expected ({}) has error: {}",
-              condition_str,
-              condition.error()),
-          file,
-          line,
-          func,
-          str);
-      FARM_IMPL_ABORT();
-    }
-  }
-};
-
-}  // namespace detail
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -250,55 +250,19 @@ inline StreamLogger& defaultLogger() {
     }                                                           \
   } while (false)
 
-namespace farm_ng {
-namespace detail {
-
-template <class TT>
-struct AssertTrue {
-  static void impl(
-      TT const& condition,
-      std::string const& condition_str,
-      std::string const& file,
-      int line,
-      std::string const& func,
-      std::string const& str) {
-    if (!condition) {
-      farm_ng::defaultLogger().log(
-          farm_ng::LogLevel::critical,
-          FARM_FORMAT(
-              "PANIC: ASSERT failed\nbool({}) not true.", condition_str),
-          file,
-          line,
-          func,
-          str);
-      FARM_IMPL_ABORT();
-    }
-  }
-};
-
-template <class TT>
-auto assertTrue(
-    TT const& condition,
-    std::string const& condition_str,
-    std::string const& file,
-    int line,
-    std::string const& func,
-    std::string const& str) {
-  AssertTrue<TT>::impl(condition, condition_str, file, line, func, str);
-}
-
-}  // namespace detail
-}  // namespace farm_ng
-
 /// If condition is false, Print formatted error message and then panic.
-#define FARM_ASSERT(condition, ...) \
-  ::farm_ng::detail::assertTrue(    \
-      (condition),                  \
-      #condition,                   \
-      __FILE__,                     \
-      __LINE__,                     \
-      __func__,                     \
-      FARM_FORMAT(__VA_ARGS__))
+#define FARM_ASSERT(condition, ...)                                            \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      farm_ng::defaultLogger().log(                                            \
+          farm_ng::LogLevel::critical,                                         \
+          FARM_FORMAT("PANIC: ASSERT failed\nbool({}) not true.", #condition), \
+          __FILE__,                                                            \
+          __LINE__,                                                            \
+          __func__ FARM_MAYBE_VARGS(__VA_ARGS__)(__VA_ARGS__));                \
+      FARM_IMPL_ABORT();                                                       \
+    }                                                                          \
+  } while (false)
 
 /// If it is false that `lhs` == `rhs`, print formatted error message and then
 /// panic.


### PR DESCRIPTION
This reverts commit 4ee7bade764f94c77564df44bc7938319958af68.

Evaluating FARM_FORMAT() and assigning it to a std::string inside the FARM_ASSERT macro caused performance regression downstream most likely due to memory allocation in inner loops, but possibly also due to the runtime performance of FARM_FORMAT.

Note this is just a quick fix. Aspects to consider for addressing this properly:

 - A similar pattern is still used in other places.
 - The code branch which uses compile-time FARM_FORMAT without memory allocation does not work anymore (but might be desirable to bring back).
 
 ----
 
 
 The offending lines:
 
 ```
 #define FARM_ASSERT(condition, ...) \
  ::farm_ng::detail::assertTrue(    \
      (condition),                  \
      #condition,                   \
      __FILE__,                     \
      __LINE__,                     \
      __func__,                     \
      FARM_FORMAT(__VA_ARGS__))
   ```

The particular problem is ``FARM_FORMAT(__VA_ARGS__)`` which is evaluated and assigned to a std::string even if ``(condition)==true``.