### PR TITLE
For some reason log_level_ can't be printed easily.

### DIFF
--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -76,7 +76,7 @@ class StreamLogger {
             "log "
             "level: {})",
             file,
-            log_level_));
+            int(log_level_)));
         flush();
       }
     }


### PR DESCRIPTION
For some reason in another code path we couldn't find the printer for log_level_.  Not sure.  @Hackerman342 can you past the traceback from the compile step?

