### PR TITLE
Enable mypy, codespell and Ruff

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run Tests
-      run: pytest -v py/tests/ # --mypy
+      run: pytest -v py/tests/ --mypy

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Run Tests
       run: pytest -v py/tests/
     - name: Run mypy
-      run: mypy
+      run: mypy py/farm_ng

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -24,4 +24,6 @@ jobs:
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run Tests
-      run: pytest -v py/tests/ --mypy
+      run: pytest -v py/tests/
+    - name: Run mypy
+      run: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,12 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [feat, fix, docs, style, refactor, perf, test, ci, build, chore, revert]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list
+          - "te"
+          - --skip
+          - "cpp/thirdparty/*,docs/package-lock.json"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,8 @@ repos:
           - "te"
           - --skip
           - "cpp/thirdparty/*,docs/package-lock.json"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.284
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,4 +68,3 @@ repos:
     rev: v0.0.284
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,48 @@
+select = [
+  "AIR",     # Airflow
+  "ASYNC",   # flake8-async
+  "BLE",     # flake8-blind-except
+  "C4",      # flake8-comprehensions
+  "C901",    # McCabe cyclomatic complexity
+  "CPY",     # Copyright-related rules
+  "DTZ",     # flake8-datetimez
+  "E",       # pycodestyle
+  "F",       # Pyflakes
+  "FLY",     # flynt
+  "I",       # isort
+  "ICN",     # flake8-import-conventions
+  "INT",     # flake8-gettext
+  "NPY",     # NumPy-specific rules
+  "PL",      # Pylint
+  "PYI",     # flake8-pyi
+  "RSE",     # flake8-raise
+  "RUF",     # Ruff-specific rules
+  "S",       # flake8-bandit
+  "SLOT",    # flake8-slots
+  "T10",     # flake8-debugger
+  "TID",     # flake8-tidy-imports
+  "UP",      # pyupgrade
+  "W",       # pycodestyle
+  "YTT",     # flake8-2020
+  # TODO: add when we push for the docs
+  # "D",   # pydocstyle
+]
+
+line-length = 120
+target-version = "py38"
+
+[mccabe]
+max-complexity = 39
+
+[pylint]
+max-args = 16
+max-branches = 45
+max-returns = 13
+max-statements = 258
+
+[per-file-ignores]
+"py/tests/*" = [
+  "S101",     # Use of `assert` detected
+  "PLR2004",  # Magic value used in comparison,
+  "RUF006",   # Store a reference to the return value of `asyncio.create_task
+]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -24,8 +24,43 @@ select = [
   "UP",      # pyupgrade
   "W",       # pycodestyle
   "YTT",     # flake8-2020
+  "SLF",     # flake8-self
+  #"A",    # flake8-builtins
+  #"ANN",  # flake8-annotations
+  #"ARG",  # flake8-unused-arguments
+  "B",    # flake8-bugbear
+  "COM",  # flake8-commas
   # TODO: add when we push for the docs
-  # "D",   # pydocstyle
+  #"D",   # pydocstyle
+  "DJ",   # flake8-django
+  "EM",   # flake8-errmsg
+  #"ERA",  # eradicate
+  "EXE",  # flake8-executable
+  "FA",   # flake8-future-annotations
+  #"FBT",  # flake8-boolean-trap
+  #"FIX",  # flake8-fixme
+  "G",    # flake8-logging-format
+  "INP",  # flake8-no-pep420
+  "ISC",  # flake8-implicit-str-concat
+  #"N",    # pep8-naming
+  "PD",   # pandas-vet
+  #"PERF", # Perflint
+  "PGH",  # pygrep-hooks
+  "PIE",  # flake8-pie
+  "PT",   # flake8-pytest-style
+  "PTH",  # flake8-use-pathlib
+  "Q",    # flake8-quotes
+  "RET",  # flake8-return
+  #"SIM",  # flake8-simplify
+  "SLF",  # flake8-self
+  #"T20",  # flake8-print
+  "TCH",  # flake8-type-checking
+  "TD",   # flake8-todos
+  "TRY",  # tryceratops
+]
+ignore = [
+  # TODO: enable when python >= 3.11
+  "PYI034",  # `__enter__` methods in classes return `self` at runtime
 ]
 
 line-length = 120
@@ -45,4 +80,5 @@ max-statements = 258
   "S101",     # Use of `assert` detected
   "PLR2004",  # Magic value used in comparison,
   "RUF006",   # Store a reference to the return value of `asyncio.create_task
+  "SLF001",   # Private member accessed
 ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cmake ../super_project
 make -j
 ```
 
-Run pre-commit before commiting changes
+Run pre-commit before committing changes
 
 ```
 pre-commit run -a

--- a/cpp/farm_ng/core/enum/enum_flags_without_ostream.h
+++ b/cpp/farm_ng/core/enum/enum_flags_without_ostream.h
@@ -116,7 +116,7 @@
       return "MyFlags";
     }
 
-   // Note: When adding new flags to an exisiting enum, we want to add such flag
+   // Note: When adding new flags to an existing enum, we want to add such flag
    // at the end.
 
     FARM_ENUMFLAGS_WITHOUT_OSTREAM(MyFlags, uint32_t, (foo, bar));

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -474,8 +474,8 @@ auto insertKeyValueInMap(
     farm_ng::defaultLogger().log(
         farm_ng::LogLevel::critical,
         FARM_FORMAT(
-            "FARM_INSERT key `{}` (={}) is already in map `{}` of size `{}`. "
-            "\nWe cannot insert value `{}`.",
+            "FARM_INSERT key `{}` (={}) is already in map `{}` of size `{}`.\n"
+            "We cannot insert value `{}`.",
             key_cstr,
             key,
             container_cstr,

--- a/cpp/farm_ng/core/logging/test_common.h
+++ b/cpp/farm_ng/core/logging/test_common.h
@@ -35,7 +35,7 @@ class CaptureStdErr {
   std::streambuf* orig_std_err_buffer_;
 };
 
-// Theses are macros so we see the line number in the test where the error
+// These are macros so we see the line number in the test where the error
 // occurs.
 #define EXPECT_CONTAINS(str, regex)              \
   EXPECT_TRUE(std::regex_search((str), (regex))) \

--- a/cpp/farm_ng/core/logging/trace_debug_log.h
+++ b/cpp/farm_ng/core/logging/trace_debug_log.h
@@ -34,7 +34,7 @@ static_assert(FARM_LOG_LEVEL_INFO == int(::farm_ng::LogLevel::info));
 
 // All other log levels (INFO, WARN, CRITICAL,...) and corresponding log macros
 // LOG_INFO, LOG_WARN are always compiled (unless globally disabled).
-// In addition for beeing defined at compile-time, logging must also be enabled
+// In addition for being defined at compile-time, logging must also be enabled
 // at run-time be specifying the appropriate run-time log level using the
 // corresponding logger, such as
 // ``defaultLogger().setLogLevel(LogLevel::trace);``

--- a/cpp/farm_ng/core/misc/shared.h
+++ b/cpp/farm_ng/core/misc/shared.h
@@ -73,16 +73,16 @@ class Shared {
     return FARM_UNWRAP(maybe);
   }
 
-  /// Returns the interior object which is guarenteed to be available
+  /// Returns the interior object which is guaranteed to be available
   TT& operator*() { return *non_null_shared_; }
 
-  /// Returns the interior object which is guarenteed to be available
+  /// Returns the interior object which is guaranteed to be available
   TT const& operator*() const { return *non_null_shared_; }
 
-  /// Returns the interior object which is guarenteed to be available
+  /// Returns the interior object which is guaranteed to be available
   TT* operator->() { return non_null_shared_.get(); }
 
-  /// Returns the interior object which is guarenteed to be available
+  /// Returns the interior object which is guaranteed to be available
   TT const* operator->() const { return non_null_shared_.get(); }
 
   // Implicit conversion to a nullable std::shared_ptr okay

--- a/docs/docs/Developer Guide/style-guide.md
+++ b/docs/docs/Developer Guide/style-guide.md
@@ -309,7 +309,7 @@ Example:
 ```
 
 Note:
- - Marcos provided by farm-ng-core in generally provide functionallity not
+ - Marcos provided by farm-ng-core in generally provide functionality not
    supported otherwise, such as line number log output for ASSERT macros,
    to/from string conversions for enums etc.
 

--- a/infra/scripts/venv_export_env_vars.sh
+++ b/infra/scripts/venv_export_env_vars.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Source this file (executing it wont set variables).
+# Source this file (executing it won't set variables).
 # Setup env vars for using libs and binaries in venv/prefix inside.
 # Required for CMake and dynamic library loading on Linux.
 

--- a/protos/farm_ng/core/lie.proto
+++ b/protos/farm_ng/core/lie.proto
@@ -33,7 +33,7 @@ message Isometry2F64 {
 }
 
 message Rotation3F64 {
-  // Quaternion which is required to be unit lenght.
+  // Quaternion which is required to be unit length.
   QuaternionF64 unit_quaternion = 1;
 }
 

--- a/py/farm_ng/core/__init__.py
+++ b/py/farm_ng/core/__init__.py
@@ -1,9 +1,5 @@
 # Version variable
-import sys
 
-if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
-    import importlib.metadata as importlib_metadata
-else:  # pragma: <3.8 cover
-    import importlib_metadata
+import importlib.metadata as importlib_metadata
 
 __version__ = importlib_metadata.version("farm_ng_core")

--- a/py/farm_ng/core/event_client.py
+++ b/py/farm_ng/core/event_client.py
@@ -95,7 +95,11 @@ class EventClient:
         Returns:
             bool: True if the connection was successful, False otherwise.
         """
-        if self.stub is not None and self.channel is not None and await self.channel.channel_ready():
+        if (
+            self.stub is not None
+            and self.channel is not None
+            and await self.channel.channel_ready()
+        ):
             self.logger.debug("Already connected to %s", self.server_address)
             return True
 
@@ -178,7 +182,7 @@ class EventClient:
         if not await self._try_connect():
             self.logger.warning("Could not list uris: %s", self.server_address)
             return []
-        
+
         if self.stub is None:
             return []
 

--- a/py/farm_ng/core/event_service.py
+++ b/py/farm_ng/core/event_service.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import logging
 import time
-from typing import AsyncIterator
+from typing import AsyncIterator, Callable
 import grpc
 from farm_ng.core import event_service_pb2_grpc
 from farm_ng.core.events_file_reader import proto_from_json_file, payload_to_protobuf
@@ -112,7 +112,7 @@ class EventServiceGrpc:
         self._uris_stats: dict[str, _UriStats] = defaultdict(_UriStats)
 
         # the request/reply handler
-        self._request_reply_handler: callable | None = None
+        self._request_reply_handler: Callable | None = None
 
         # add the service to the asyncio server
         event_service_pb2_grpc.add_EventServiceServicer_to_server(self, server)
@@ -133,12 +133,12 @@ class EventServiceGrpc:
         return self._logger
 
     @property
-    def request_reply_handler(self) -> callable | None:
+    def request_reply_handler(self) -> Callable | None:
         """Returns the request/reply handler."""
         return self._request_reply_handler
 
     @request_reply_handler.setter
-    def request_reply_handler(self, handler: callable) -> None:
+    def request_reply_handler(self, handler: Callable) -> None:
         """Sets the request/reply handler."""
         self._request_reply_handler = handler
 
@@ -450,7 +450,7 @@ async def test_req_rep_handler_smoke(
 # main function to run the service and all the async tasks
 async def test_main(args, event_service: EventServiceGrpc) -> None:
     # define the async tasks
-    async_tasks: list[asyncio.Task] = []
+    async_tasks = []
 
     event_service.request_reply_handler = test_req_rep_handler_smoke
 

--- a/py/farm_ng/core/event_service.py
+++ b/py/farm_ng/core/event_service.py
@@ -148,7 +148,7 @@ class EventServiceGrpc:
         return self._counts
 
     @property
-    def uris(self) -> dict[str, str]:
+    def uris(self) -> dict[str, Uri]:
         """Returns the URIs of the service."""
         return self._uris
 

--- a/py/farm_ng/core/event_service_recorder.py
+++ b/py/farm_ng/core/event_service_recorder.py
@@ -205,7 +205,7 @@ def get_file_name_base() -> str:
         '2021_08_31_15_54_00_000000_ubuntu'
     """
     return (
-        datetime.now(DATETIME_FORMAT).strftime(DATETIME_FORMAT) + "_" + get_host_name()
+        datetime.now(DEFAULT_TIMEZONE).strftime(DATETIME_FORMAT) + "_" + get_host_name()
     )
 
 

--- a/py/farm_ng/core/event_service_recorder.py
+++ b/py/farm_ng/core/event_service_recorder.py
@@ -152,6 +152,9 @@ class EventServiceRecorder:
             extension (str, optional): the extension of the file. Defaults to ".bin".
             max_file_mb (int, optional): the maximum size of the file in MB. Defaults to 0.
         """
+        if self.recorder_config is None:
+            raise ValueError("recorder_config is None")
+
         # create the tasks list. the first task is the record task
         async_tasks: list[asyncio.Task] = [
             asyncio.create_task(
@@ -255,7 +258,7 @@ class RecorderService:
     async def stop_recording(self) -> None:
         """Stops recording the events to a file."""
         # do nothing if not recording
-        if self._recorder is None:
+        if self._recorder is None or self._recorder_task is None:
             return
 
         self._recorder.logger.info("stopping recording")

--- a/py/farm_ng/core/event_service_tool.py
+++ b/py/farm_ng/core/event_service_tool.py
@@ -6,28 +6,27 @@ This will print a config file will all the uris currently being published by the
 
 python -m farm_ng.core.event_service_tool config-gen config2.json
 
-This print a sample config file with a single service called test_service, and an example recorder service configuration (note with no port numbers so scripts no not to connect)
-
+This print a sample config file with a single service called test_service, and an example
+recorder service configuration (note with no port numbers so scripts no not to connect)
 
 Runs a single service from the config file
 
 python -m farm_ng.core.event_service_tool launch1 --service-config config.json --service-name test_service
 
 """
-import signal
 import argparse
-import sys
 import asyncio
+import sys
+
+from farm_ng.core.event_client import EventClient
+from farm_ng.core.event_service import add_service_parser, load_service_config
 from farm_ng.core.event_service_pb2 import (
-    EventServiceConfigList,
     EventServiceConfig,
+    EventServiceConfigList,
     SubscribeRequest,
 )
-from farm_ng.core.uri_pb2 import Uri
 from farm_ng.core.events_file_writer import proto_to_json_file
-from farm_ng.core.events_file_reader import proto_from_json_file
-from farm_ng.core.event_client import EventClient
-from farm_ng.core.event_service import load_service_config, add_service_parser
+from farm_ng.core.uri_pb2 import Uri
 from google.protobuf.json_format import MessageToJson
 
 

--- a/py/farm_ng/core/event_service_tool.py
+++ b/py/farm_ng/core/event_service_tool.py
@@ -41,8 +41,9 @@ async def config_gen_command(args):
                     port=args.port,
                     subscriptions=[
                         SubscribeRequest(
-                            uri=Uri(path="/test", query="service_name=bar"), every_n=1
-                        )
+                            uri=Uri(path="/test", query="service_name=bar"),
+                            every_n=1,
+                        ),
                     ],
                     args=["--my-arg=my-value", "foo"],
                     log_level=EventServiceConfig.LogLevel.INFO,
@@ -53,10 +54,10 @@ async def config_gen_command(args):
                         SubscribeRequest(
                             uri=Uri(path="*", query="service_name={args.name}"),
                             every_n=1,
-                        )
+                        ),
                     ],
                 ),
-            ]
+            ],
         ),
     )
 

--- a/py/farm_ng/core/events_file_reader.py
+++ b/py/farm_ng/core/events_file_reader.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import argparse
 import importlib
 from dataclasses import dataclass
 from pathlib import Path
@@ -9,13 +10,13 @@ from typing import Generator
 from typing import Type
 import struct
 import json
+import sys
 
 from farm_ng.core.uri import uri_query_to_dict
 from farm_ng.core.event_pb2 import Event
 from farm_ng.core.uri_pb2 import Uri
 from google.protobuf.message import Message
 from google.protobuf import json_format
-import argparse
 
 # public symbols
 
@@ -342,6 +343,9 @@ class EventsFileReader:
         Yields:
             Generator[tuple[Event, Message], None, None]: the event and message
         """
+        if self._file_stream is None:
+            raise IOError("Reader not open. Please, use reader.open()")
+
         self._file_stream.seek(0)
         try:
             while True:

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -142,8 +142,9 @@ class EventsFileWriter:
         return self.is_closed()
 
     def write_event_payload(self, event: Event, payload: bytes) -> None:
-        if not self.is_closed:
+        if not self.is_closed():
             raise RuntimeError(f"Event log is not open: {self.file_name}")
+
         assert event.payload_length == len(
             payload
         ), f"Payload length mismatch {event.payload_length} != {len(payload)}"

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -142,7 +142,7 @@ class EventsFileWriter:
         return self.is_closed()
 
     def write_event_payload(self, event: Event, payload: bytes) -> None:
-        if not self.is_closed():
+        if self.is_closed():
             raise RuntimeError(f"Event log is not open: {self.file_name}")
 
         assert event.payload_length == len(

--- a/py/farm_ng/core/pose_tree.py
+++ b/py/farm_ng/core/pose_tree.py
@@ -1,27 +1,40 @@
-from farm_ng.core import pose_pb2
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from farm_ng.core import lie_pb2, pose_pb2
 
 # Usage example:
 # pose_tree = ... # Load your PoseTree proto object here.
 # result = find_poses_by_frames(pose_tree, "base_link", "wheel_link")
 # print(result)
 
+# NOTE: pep8-naming throws an error here because names should be snake_case.
 
-def find_transform(pose_tree: pose_pb2.PoseTree, frame_A: str, frame_B: str):
+
+def find_transform(
+    pose_tree: pose_pb2.PoseTree,
+    frame_A: str,
+    frame_B: str,
+) -> lie_pb2.Isometry3F64 | None:
     """Find all poses in a PoseTree with a given frame_A and frame_B.
-       If frames are inverted, returns the inverse transform.
+
+    If frames are inverted, returns the inverse transform.
 
     Args:
-    - pose_tree (PoseTree): The PoseTree proto object to search within.
-    - frame_A (str): The desired frame_A value.
-    - frame_B (str): The desired frame_B value.
+        pose_tree (PoseTree): The PoseTree proto object to search within.
+        frame_A (str): The desired frame_A value.
+        frame_B (str): The desired frame_B value.
 
     Returns:
-    - Pose: Pose objects that match the criteria.
+        Pose: Pose objects that match the criteria.
     """
-
+    pose: pose_pb2.Pose
     for pose in pose_tree.poses:
         if pose.frame_A == frame_A and pose.frame_B == frame_B:
             return pose.B_from_A
-        elif pose.frame_A == frame_B and pose.frame_B == frame_A:
+        if pose.frame_A == frame_B and pose.frame_B == frame_A:
             print("NOT IMPLEMENTED, please swap your frames")
             return None
+    return None

--- a/py/farm_ng/core/stamp.py
+++ b/py/farm_ng/core/stamp.py
@@ -1,5 +1,6 @@
 import time
 from dataclasses import dataclass
+
 from farm_ng.core.timestamp_pb2 import Timestamp
 from farm_ng.core.uri import get_host_name
 

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import platform
+from dataclasses import dataclass, field
 
 from farm_ng.core import uri_pb2
 from google.protobuf.message import Message
 
 
+def _get_platform_node() -> str:
+    return platform.node()
+
+
 @dataclass
 class PlatformConfig:
-    host_name: str = platform.node()
+    host_name: str = field(default_factory=_get_platform_node)
 
 
 # https://vald-phoenix.github.io/pylint-errors/plerr/errors/variables/W0603.html

--- a/py/farm_ng/core/uri.py
+++ b/py/farm_ng/core/uri.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import platform
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from farm_ng.core import uri_pb2
-from google.protobuf.message import Message
+
+if TYPE_CHECKING:
+    from google.protobuf.message import Message
 
 
 def _get_platform_node() -> str:
@@ -22,7 +25,6 @@ platform_config = PlatformConfig()
 
 def set_host_name(name: str) -> None:
     # global HOST_NAME
-    # HOST_NAME = name
     platform_config.host_name = name
 
 
@@ -57,5 +59,4 @@ def string_to_uri(string: str) -> uri_pb2.Uri:
 
 
 def uri_query_to_dict(uri: uri_pb2.Uri) -> dict[str, str]:
-    query = dict([x.split("=") for x in uri.query.split("&")])
-    return query
+    return dict([x.split("=") for x in uri.query.split("&")])

--- a/py/tests/event_common.py
+++ b/py/tests/event_common.py
@@ -51,5 +51,5 @@ def event_service_config_list() -> EventServiceConfigList:
                     ),
                 ],
             ),
-        ]
+        ],
     )

--- a/py/tests/test_core.py
+++ b/py/tests/test_core.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List
 
 import pytest
 from farm_ng.core import event_pb2, timestamp_pb2, uri_pb2
@@ -42,7 +43,7 @@ def test_event_has_message() -> None:
                 stamp=0.0,
                 clock_name="test/monotonic",
                 semantics="test/monotonic",
-            )
+            ),
         ],
         payload_length=11,
     )
@@ -194,7 +195,7 @@ class TestEventsReader:
 
             # test get/has uris
             assert len(reader.events_index) == 0
-            all_events: List[EventLogPosition] = reader.get_index()
+            all_events: list[EventLogPosition] = reader.get_index()
             assert len(reader.events_index) > 0
 
             events: dict = {}
@@ -218,34 +219,42 @@ class TestEventsReader:
 class TestEventsJson:
     def test_json_write_read_path(self, tmp_path: Path) -> None:
         stamp = timestamp_pb2.Timestamp(
-            stamp=1.2, clock_name="clock0", semantics="test/proto"
+            stamp=1.2,
+            clock_name="clock0",
+            semantics="test/proto",
         )
 
         # Test write w/ str, read w/ Path
         assert proto_to_json_file(tmp_path / "test.json", stamp)
         assert stamp == proto_from_json_file(
-            tmp_path / "test.json", timestamp_pb2.Timestamp()
+            tmp_path / "test.json",
+            timestamp_pb2.Timestamp(),
         )
 
         # Test overwrite
         assert proto_to_json_file(tmp_path / "test.json", stamp)
         assert stamp == proto_from_json_file(
-            tmp_path / "test.json", timestamp_pb2.Timestamp()
+            tmp_path / "test.json",
+            timestamp_pb2.Timestamp(),
         )
 
     def test_json_write_read_str(self, tmp_path: Path) -> None:
         stamp = timestamp_pb2.Timestamp(
-            stamp=9.67832, clock_name="clock1", semantics="test/proto_again"
+            stamp=9.67832,
+            clock_name="clock1",
+            semantics="test/proto_again",
         )
 
         # Test write w/ Path, read w/ str
         assert proto_to_json_file(tmp_path / "test_1.json", stamp)
         assert stamp == proto_from_json_file(
-            f"{tmp_path}/test_1.json", timestamp_pb2.Timestamp()
+            f"{tmp_path}/test_1.json",
+            timestamp_pb2.Timestamp(),
         )
 
         # Test overwrite
         assert proto_to_json_file(tmp_path / "test_1.json", stamp)
         assert stamp == proto_from_json_file(
-            f"{tmp_path}/test_1.json", timestamp_pb2.Timestamp()
+            f"{tmp_path}/test_1.json",
+            timestamp_pb2.Timestamp(),
         )

--- a/py/tests/test_core.py
+++ b/py/tests/test_core.py
@@ -1,17 +1,17 @@
-from typing import List
 from pathlib import Path
+from typing import List
 
 import pytest
+from farm_ng.core import event_pb2, timestamp_pb2, uri_pb2
 from farm_ng.core.events_file_reader import (
-    EventsFileReader,
     EventLogPosition,
-    event_has_message,
+    EventsFileReader,
     _parse_protobuf_descriptor,
+    event_has_message,
     proto_from_json_file,
 )
 from farm_ng.core.events_file_writer import EventsFileWriter, proto_to_json_file
 from farm_ng.core.stamp import get_monotonic_now
-from farm_ng.core import event_pb2, timestamp_pb2, uri_pb2
 
 
 @pytest.fixture(name="log_base")
@@ -201,7 +201,7 @@ class TestEventsReader:
 
             for event_log in all_events:
                 path: str = event_log.event.uri.path
-                if not path in events:
+                if path not in events:
                     events[path] = []
                 events[path].append(event_log)
 

--- a/py/tests/test_core.py
+++ b/py/tests/test_core.py
@@ -185,6 +185,7 @@ class TestEventsReader:
             assert reader.is_open()
             count = 0
             for event, message in reader.read_messages():
+                assert isinstance(message, timestamp_pb2.Timestamp)
                 if event.uri.path == "hello":
                     assert message.stamp == count
                 elif event.uri.path == "world":
@@ -206,9 +207,10 @@ class TestEventsReader:
 
             for path, _ in events.items():
                 for i, event_log in enumerate(events[path]):
-                    message = reader.read_message(event_log)
-                    assert message == event_log.read_message()
-                    assert message.stamp == i
+                    _message = reader.read_message(event_log)
+                    assert isinstance(_message, timestamp_pb2.Timestamp)
+                    assert _message == event_log.read_message()
+                    assert _message.stamp == i
 
         assert reader.close()
 

--- a/py/tests/test_event_client.py
+++ b/py/tests/test_event_client.py
@@ -40,7 +40,7 @@ class TestEventClient:
         client: EventClient = event_client()
 
         # create a queue to collect messages
-        queue = asyncio.Queue()
+        queue: asyncio.Queue[int] = asyncio.Queue()
 
         asyncio.create_task(subscribe_callback(client, queue))
         await asyncio.sleep(0.001)

--- a/py/tests/test_event_client.py
+++ b/py/tests/test_event_client.py
@@ -29,6 +29,7 @@ class TestEventClient:
             async for _, message in client.subscribe(
                 request=client.config.subscriptions[0], decode=True
             ):
+                assert isinstance(message, Int32Value)
                 await queue.put(message.value + 1)
 
         # create a service

--- a/py/tests/test_event_client.py
+++ b/py/tests/test_event_client.py
@@ -1,11 +1,10 @@
-import pytest
 import asyncio
-import grpc
-from google.protobuf.wrappers_pb2 import Int32Value
 
+import grpc
+import pytest
 from farm_ng.core.event_client import EventClient
-from farm_ng.core.event_service import EventServiceConfig
-from farm_ng.core.event_service import EventServiceGrpc, EventServiceConfig
+from farm_ng.core.event_service import EventServiceConfig, EventServiceGrpc
+from google.protobuf.wrappers_pb2 import Int32Value
 
 from .event_common import event_service_config
 

--- a/py/tests/test_event_client.py
+++ b/py/tests/test_event_client.py
@@ -22,11 +22,12 @@ class TestEventClient:
         assert client.logger.name == "test_service/client"
         assert client.server_address == "localhost:50051"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_publish_subscribe(self) -> None:
         async def subscribe_callback(client: EventClient, queue: asyncio.Queue):
             async for _, message in client.subscribe(
-                request=client.config.subscriptions[0], decode=True
+                request=client.config.subscriptions[0],
+                decode=True,
             ):
                 assert isinstance(message, Int32Value)
                 await queue.put(message.value + 1)

--- a/py/tests/test_event_service.py
+++ b/py/tests/test_event_service.py
@@ -86,7 +86,7 @@ class TestEventServiceGrpc:
     @pytest.mark.asyncio
     async def test_multiple_publishers(self) -> None:
         async def _publish_message(
-            event_service: EventServiceGrpc, path: str, num_messages: int, delay: int
+            event_service: EventServiceGrpc, path: str, num_messages: int, delay: float
         ) -> bool:
             """Publishes a message to the event service."""
             for i in range(num_messages):
@@ -101,7 +101,7 @@ class TestEventServiceGrpc:
         asyncio.create_task(event_service.serve())
 
         # create multiple publishers
-        async_tasks: list[asyncio.Task] = []
+        async_tasks = []
         async_tasks.append(_publish_message(event_service, "/foo", 2, 0.2))
         async_tasks.append(_publish_message(event_service, "/bar", 3, 0.1))
 

--- a/py/tests/test_event_service.py
+++ b/py/tests/test_event_service.py
@@ -25,7 +25,7 @@ class TestEventServiceGrpc:
         assert not servicer.counts
         assert servicer.request_reply_handler is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_publish(self) -> None:
         # create a service
         event_service = EventServiceGrpc(grpc.aio.server(), event_service_config())
@@ -61,7 +61,7 @@ class TestEventServiceGrpc:
         assert event_service.counts["/bar"] == 1
         assert event_service.uris["/bar"].query == message_uri.query
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_publish_error(self) -> None:
         # create a service
         event_service = EventServiceGrpc(grpc.aio.server(), event_service_config())
@@ -74,14 +74,18 @@ class TestEventServiceGrpc:
 
         # publish a message with a different type
         with pytest.raises(
-            TypeError, match="Message type mismatch: StringValue != Int32Value"
+            TypeError,
+            match="Message type mismatch: StringValue != Int32Value",
         ):
             await event_service.publish(path="/foo", message=Int32Value(value=0))
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_multiple_publishers(self) -> None:
         async def _publish_message(
-            event_service: EventServiceGrpc, path: str, num_messages: int, delay: float
+            event_service: EventServiceGrpc,
+            path: str,
+            num_messages: int,
+            delay: float,
         ) -> bool:
             """Publishes a message to the event service."""
             for i in range(num_messages):

--- a/py/tests/test_event_service.py
+++ b/py/tests/test_event_service.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
-import pytest
+
 import asyncio
+
 import grpc
-
+import pytest
+from farm_ng.core.event_service import EventServiceConfig, EventServiceGrpc
 from google.protobuf.wrappers_pb2 import Int32Value, StringValue
-from google.protobuf.message import Message
 
-from farm_ng.core.events_file_reader import payload_to_protobuf
-from farm_ng.core.event_service_pb2 import (
-    EventServiceConfig,
-    RequestReplyRequest,
-)
-from farm_ng.core.event_service import EventServiceGrpc, EventServiceConfig
 from .event_common import event_service_config
 
 

--- a/py/tests/test_event_service_recorder.py
+++ b/py/tests/test_event_service_recorder.py
@@ -16,11 +16,12 @@ from .event_common import event_service_config_list
 
 
 async def request_reply_handler(
-    event_service: EventServiceGrpc, request: RequestReplyRequest
+    event_service: EventServiceGrpc,
+    request: RequestReplyRequest,
 ) -> Message:
     message = payload_to_protobuf(request.event, request.payload)
     event_service.logger.info(
-        f"Received: {request.event.uri.path} {request.event.sequence} {message}".rstrip()
+        f"Received: {request.event.uri.path} {request.event.sequence} {message}".rstrip(),
     )
     return message  # echo message back
 
@@ -29,7 +30,8 @@ class TestEventServiceRecorder:
     def test_smoke(self) -> None:
         config_list: EventServiceConfigList = event_service_config_list()
         recorder_service = EventServiceRecorder(
-            service_name="record_default", config_list=config_list
+            service_name="record_default",
+            config_list=config_list,
         )
 
         assert recorder_service is not None
@@ -40,7 +42,7 @@ class TestEventServiceRecorder:
         assert recorder_service.logger.name == "record_default"
         assert recorder_service.record_queue.qsize() == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_record(self, tmp_path: Path) -> None:
         config_list: EventServiceConfigList = event_service_config_list()
 
@@ -48,7 +50,8 @@ class TestEventServiceRecorder:
         event_service.request_reply_handler = request_reply_handler
 
         recorder_service = EventServiceRecorder(
-            service_name="record_default", config_list=config_list
+            service_name="record_default",
+            config_list=config_list,
         )
 
         # start the event service
@@ -57,8 +60,7 @@ class TestEventServiceRecorder:
         # start the subcriber and record
         file_name = tmp_path / "test_record"
         task = asyncio.create_task(
-            # TODO: parametrize the test
-            recorder_service.subscribe_and_record(file_name)
+            recorder_service.subscribe_and_record(file_name),
         )
 
         # we need to wait for the subscribe callback to be called

--- a/py/tests/test_event_service_recorder.py
+++ b/py/tests/test_event_service_recorder.py
@@ -1,16 +1,17 @@
-import pytest
 import asyncio
 from pathlib import Path
-import grpc
-from google.protobuf.wrappers_pb2 import Int32Value
-from google.protobuf.message import Message
 
-from farm_ng.core.events_file_reader import EventsFileReader, payload_to_protobuf
+import grpc
+import pytest
 from farm_ng.core.event_service import EventServiceConfigList, EventServiceGrpc
-from farm_ng.core.event_service_recorder import EventServiceRecorder
 from farm_ng.core.event_service_pb2 import (
     RequestReplyRequest,
 )
+from farm_ng.core.event_service_recorder import EventServiceRecorder
+from farm_ng.core.events_file_reader import EventsFileReader, payload_to_protobuf
+from google.protobuf.message import Message
+from google.protobuf.wrappers_pb2 import Int32Value
+
 from .event_common import event_service_config_list
 
 

--- a/py/tests/test_uri.py
+++ b/py/tests/test_uri.py
@@ -4,7 +4,9 @@ from farm_ng.core.uri import make_proto_uri, string_to_uri, uri_to_string
 
 def test_make_proto():
     stamp = timestamp_pb2.Timestamp(
-        stamp=1.2, clock_name="clock0", semantics="test/proto"
+        stamp=1.2,
+        clock_name="clock0",
+        semantics="test/proto",
     )
     uri: uri_pb2.Uri = make_proto_uri("tik/tok", stamp)
     assert uri.scheme == "protobuf"

--- a/py/tests/test_uri.py
+++ b/py/tests/test_uri.py
@@ -1,6 +1,5 @@
-from farm_ng.core import uri_pb2
-from farm_ng.core import timestamp_pb2
-from farm_ng.core.uri import make_proto_uri, uri_to_string, string_to_uri
+from farm_ng.core import timestamp_pb2, uri_pb2
+from farm_ng.core.uri import make_proto_uri, string_to_uri, uri_to_string
 
 
 def test_make_proto():

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,8 @@ dev =
 files = py/farm_ng, py/tests
 ignore_missing_imports = True
 # types-protobuf fix: https://github.com/python/typeshed/issues/7519
-namespace_packages = True
+#namespace_packages = True
+check_untyped_defs = True
 
 [options.package_data]
 farm_ng.core =

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,9 +60,11 @@ dev =
 
 [mypy]
 files = py/farm_ng, py/tests
+# exclude the generated protobuf files and the stubs
+exclude = (_pb2\.py$|\.pyi$)
 ignore_missing_imports = True
 # types-protobuf fix: https://github.com/python/typeshed/issues/7519
-#namespace_packages = True
+namespace_packages = True
 check_untyped_defs = True
 
 [options.package_data]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
-from setuptools import setup
-
 from farm_ng.package.commands import (
-    CleanFilesCommand,
-    BuildProtosInstall,
     BuildProtosDevelop,
     BuildProtosEggInfo,
+    BuildProtosInstall,
+    CleanFilesCommand,
 )
+from setuptools import setup
 
 PROTO_ROOT: str = "protos"
 PACKAGE_ROOT: str = "py"
@@ -27,5 +26,5 @@ setup(
         "develop": BuildProtosDevelop,
         "egg_info": BuildProtosEggInfo,
         "clean": CleanFilesCommand,
-    }
+    },
 )


### PR DESCRIPTION
- adds back `mypy` in the ci
- introduces codespell for both python & c++
- introducess ruff for python code

To test:
- ci should be enough
- optional: try to record and playback some data from using cli apps

```bash
# or try running the event_service_recorder in service mode:
# start the service
python -m farm_ng.core.event_service_recorder service --service-config config.json --service-name recorder

# in a separate terminal, start recording
python -m farm_ng.core.event_service_recorder start --service-config config.json  --service-name recorder
# then stop recording
python -m farm_ng.core.event_service_recorder stop --service-config config.json  --service-name recorder

# then try playing back log file:
python -m farm_ng.core.events_file_reader playback foo.0000.bin
```