### PR TITLE
proto_conv

### DIFF
--- a/cpp/farm_ng/core/misc/proto/conv.cpp
+++ b/cpp/farm_ng/core/misc/proto/conv.cpp
@@ -18,11 +18,13 @@
 
 namespace farm_ng {
 
-auto fromProto(core::proto::Uri const& proto) -> Uri {
+template <>
+auto fromProt(core::proto::Uri const& proto) -> Expected<Uri> {
   return Uri(proto.scheme(), proto.authority(), proto.path(), proto.query());
 }
 
-auto toProto(Uri const& uri) -> core::proto::Uri {
+template <>
+core::proto::Uri toProt(Uri const& uri) {
   core::proto::Uri proto;
   proto.set_scheme(uri.scheme);
   proto.set_authority(uri.authority);

--- a/cpp/farm_ng/core/misc/proto/conv.h
+++ b/cpp/farm_ng/core/misc/proto/conv.h
@@ -16,14 +16,12 @@
 
 #include "farm_ng/core/logging/expected.h"
 #include "farm_ng/core/misc/uri.h"
+#include "farm_ng/core/proto_conv/proto_conv.h"
 
 #include <farm_ng/core/uri.pb.h>
 
 namespace farm_ng {
 
-/// Convert proto::Uri to Uri.
-Uri fromProto(farm_ng::core::proto::Uri const& proto);
-/// Convert Uri to proto::Uri.
-farm_ng::core::proto::Uri toProto(Uri const& uri);
+FARM_PROTO_CONV_TRAIT(Uri, core::proto::Uri);
 
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/misc/proto/conv_test.cpp
+++ b/cpp/farm_ng/core/misc/proto/conv_test.cpp
@@ -22,7 +22,7 @@ using namespace farm_ng;
 TEST(to_from_proto, uri) {  // NOLINT
   Uri uri("other", "[authority]", "foo/bar", "in=input");
 
-  Expected<Uri> maybe_to_from_uri = fromProto(toProto(uri));
+  Expected<Uri> maybe_to_from_uri = fromProt(toProt(uri));
   auto to_from_uri = FARM_UNWRAP(maybe_to_from_uri);
 
   FARM_ASSERT_EQ(uri.string(), "other://[authority]/foo/bar?in=input");

--- a/cpp/farm_ng/core/proto_conv/geometry/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/geometry/CMakeLists.txt
@@ -13,3 +13,9 @@ target_link_libraries(farm_ng_core_proto_conv_geometry PUBLIC
   farm_ng_core::farm_ng_core_prototools
   farm_ng_core_proto_defs
   farm_ng_core::farm_ng_core_proto_conv_linalg)
+
+
+farm_ng_add_test(conv
+              PARENT_LIBRARY farm_ng_core_proto_conv_geometry
+              LINK_LIBRARIES farm_ng_core_proto_conv_geometry
+              LABELS small)

--- a/cpp/farm_ng/core/proto_conv/geometry/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/geometry/conv.cpp
@@ -16,30 +16,39 @@
 
 #include "farm_ng/core/proto_conv/linalg/conv.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-Expected<sophus::UnitVector3F64> fromProto(proto::UnitVec3F64 const& proto) {
-  return sophus::UnitVector3F64::tryFromUnitVector(fromProto(proto.vec3()));
+template <>
+auto fromProt<core::proto::UnitVec3F64>(core::proto::UnitVec3F64 const& proto)
+    -> Expected<sophus::UnitVector3F64> {
+  FARM_TRY(auto, vec3, fromProt(proto.vec3()));
+  return sophus::UnitVector3F64::tryFromUnitVector(vec3);
 }
 
-proto::UnitVec3F64 toProto(sophus::UnitVector3F64 const& uvec) {
-  proto::UnitVec3F64 proto;
-  *proto.mutable_vec3() = toProto(uvec.params());
+template <>
+auto toProt<sophus::UnitVector3F64>(sophus::UnitVector3F64 const& uvec)
+    -> core::proto::UnitVec3F64 {
+  core::proto::UnitVec3F64 proto;
+  *proto.mutable_vec3() = toProt(uvec.params());
   return proto;
 }
 
-Expected<Eigen::Hyperplane<double, 3>> fromProto(
-    proto::Hyperplane3F64 const& proto) {
-  SOPHUS_TRY(sophus::UnitVector3F64, normal, fromProto(proto.normal()));
+template <>
+auto fromProt<core::proto::Hyperplane3F64>(
+    core::proto::Hyperplane3F64 const& proto)
+    -> Expected<Eigen::Hyperplane<double, 3>> {
+  SOPHUS_TRY(sophus::UnitVector3F64, normal, fromProt(proto.normal()));
   return Eigen::Hyperplane<double, 3>{normal.params(), proto.offset()};
 }
 
-proto::Hyperplane3F64 toProto(Eigen::Hyperplane<double, 3> const& plane) {
-  proto::Hyperplane3F64 proto;
+template <>
+auto toProt<Eigen::Hyperplane<double, 3>>(
+    Eigen::Hyperplane<double, 3> const& plane) -> core::proto::Hyperplane3F64 {
+  core::proto::Hyperplane3F64 proto;
   *proto.mutable_normal() =
-      toProto(sophus::UnitVector3F64::fromVectorAndNormalize(plane.normal()));
+      toProt(sophus::UnitVector3F64::fromVectorAndNormalize(plane.normal()));
   proto.set_offset(plane.offset());
   return proto;
 }
 
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/geometry/conv.h
+++ b/cpp/farm_ng/core/proto_conv/geometry/conv.h
@@ -15,15 +15,14 @@
 #pragma once
 
 #include "farm_ng/core/geometry.pb.h"
+#include "farm_ng/core/proto_conv/proto_conv.h"
 #include "sophus/geometry/ray.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-Expected<sophus::UnitVector3F64> fromProto(proto::UnitVec3F64 const& proto);
-proto::UnitVec3F64 toProto(sophus::UnitVector3F64 const& uvec);
+using Hyperplane3d = Eigen::Hyperplane<double, 3>;
 
-Expected<Eigen::Hyperplane<double, 3>> fromProto(
-    proto::Hyperplane3F64 const& proto);
-proto::Hyperplane3F64 toProto(Eigen::Hyperplane<double, 3> const& plane);
+FARM_PROTO_CONV_TRAIT(sophus::UnitVector3F64, core::proto::UnitVec3F64);
+FARM_PROTO_CONV_TRAIT(Hyperplane3d, core::proto::Hyperplane3F64);
 
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/geometry/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/geometry/conv_test.cpp
@@ -12,8 +12,30 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "farm_ng/core/proto_conv/lie/conv.h"
+#include "farm_ng/core/proto_conv/geometry/conv.h"
 
 #include <gtest/gtest.h>
 
 using namespace sophus;
+
+using namespace farm_ng;
+using namespace farm_ng::core;
+
+TEST(conv_geometry, unit) {
+  {
+    auto uvec = sophus::UnitVector3F64::fromVectorAndNormalize({1.0, 2.0, 3.0});
+    proto::UnitVec3F64 proto = toProt(uvec);
+    EXPECT_EQ(proto.vec3().x(), uvec.vector().x());
+    EXPECT_EQ(proto.vec3().y(), uvec.vector().y());
+    EXPECT_EQ(proto.vec3().z(), uvec.vector().z());
+
+    auto maybe_uvec2 = fromProt(proto);
+    sophus::UnitVector3F64 uvec2 = FARM_UNWRAP(maybe_uvec2);
+    EXPECT_EQ(uvec2.vector(), uvec.vector());
+    auto vec = uvec2.vector();
+    EXPECT_NEAR(vec.norm(), 1.0, 1e-6);
+    EXPECT_EQ(vec.x(), proto.vec3().x());
+    EXPECT_EQ(vec.y(), proto.vec3().y());
+    EXPECT_EQ(vec.z(), proto.vec3().z());
+  }
+}

--- a/cpp/farm_ng/core/proto_conv/image/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/image/CMakeLists.txt
@@ -14,3 +14,8 @@ target_link_libraries(farm_ng_core_proto_conv_image PUBLIC
   farm_ng_core::farm_ng_core_proto_conv_linalg
   Sophus::sophus_image
 )
+
+farm_ng_add_test(conv
+              PARENT_LIBRARY farm_ng_core_proto_conv_image
+              LINK_LIBRARIES farm_ng_core_proto_conv_image
+              LABELS small)

--- a/cpp/farm_ng/core/proto_conv/image/conv.h
+++ b/cpp/farm_ng/core/proto_conv/image/conv.h
@@ -15,33 +15,26 @@
 #pragma once
 
 #include "farm_ng/core/image.pb.h"
+#include "farm_ng/core/proto_conv/proto_conv.h"
 #include "sophus/image/dyn_image_types.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-sophus::ImageSize fromProto(proto::ImageSize const& proto);
-proto::ImageSize toProto(sophus::ImageSize const& image_size);
+FARM_PROTO_CONV_TRAIT(sophus::ImageSize, core::proto::ImageSize);
+FARM_PROTO_CONV_TRAIT(sophus::ImageLayout, core::proto::ImageLayout);
+FARM_PROTO_CONV_TRAIT(sophus::PixelFormat, core::proto::PixelFormat);
+FARM_PROTO_CONV_TRAIT(sophus::AnyImage<>, core::proto::DynImage);
 
-sophus::ImageLayout fromProto(proto::ImageLayout const& proto);
-proto::ImageLayout toProto(sophus::ImageLayout const& layout);
-
-Expected<sophus::PixelFormat> fromProto(proto::PixelFormat const& proto);
-proto::PixelFormat toProto(sophus::PixelFormat const& layout);
-
-Expected<sophus::AnyImage<>> fromProto(proto::DynImage const& proto);
 Expected<sophus::IntensityImage<>> intensityImageFromProto(
-    proto::DynImage const& proto);
+    core::proto::DynImage const& proto);
 
-template <class TPredicate>
-proto::DynImage toProto(sophus::DynImage<TPredicate> const& image) {
-  proto::DynImage proto;
-  *proto.mutable_layout() = toProto(image.layout());
-  *proto.mutable_pixel_format() = toProto(image.pixelFormat());
-  proto.set_data(
-      std::string(image.rawPtr(), image.rawPtr() + image.sizeBytes()));
+template <>
+struct ToProtoTrait<sophus::IntensityImage<>> {
+  using ProtoType = core::proto::DynImage;
+};
 
-  SOPHUS_ASSERT_EQ(size_t(image.layout().sizeBytes()), proto.data().size());
+template <>
+auto toProt<sophus::IntensityImage<>>(sophus::IntensityImage<> const& cpp)
+    -> core::proto::DynImage;
 
-  return proto;
-}
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/image/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/image/conv_test.cpp
@@ -16,12 +16,14 @@
 
 #include <gtest/gtest.h>
 
-namespace sophus::test {
+namespace farm_ng::test {
+
+using namespace sophus;
 
 template <class TPixel>
 void testPixelFormat() {
   auto format_in = PixelFormat::fromTemplate<TPixel>();
-  auto maybe_format = fromProto(toProto(format_in));
+  auto maybe_format = fromProt(toProt(format_in));
   PixelFormat format_out = SOPHUS_UNWRAP(maybe_format);
   SOPHUS_ASSERT_EQ(format_in, format_out);
 }
@@ -37,8 +39,8 @@ void testDynImage(std::vector<TPixel> const& pixels) {
     }
   }
   DynImage<> dyn_image_in(std::move(mut_image));
-  auto proto = toProto(dyn_image_in);
-  auto maybe_dyn_image = fromProto(proto);
+  auto proto = toProt(dyn_image_in);
+  auto maybe_dyn_image = fromProt(proto);
 
   DynImage<> dyn_image_out = SOPHUS_UNWRAP(maybe_dyn_image);
   SOPHUS_ASSERT_IMAGE_EQ(
@@ -56,7 +58,7 @@ void testIntensityImage(std::vector<TPixel> const& pixels) {
     }
   }
   IntensityImage<> dyn_image_in(std::move(mut_image));
-  auto proto = toProto(dyn_image_in);
+  auto proto = toProt(dyn_image_in);
   auto maybe_dyn_image = intensityImageFromProto(proto);
   IntensityImage<> dyn_image_out = SOPHUS_UNWRAP(maybe_dyn_image);
 
@@ -66,11 +68,11 @@ void testIntensityImage(std::vector<TPixel> const& pixels) {
 
 TEST(conv_image, roundtrip) {
   ImageSize size_in(600, 480);
-  ImageSize size_out = fromProto(toProto(size_in));
+  ImageSize size_out = *fromProt(toProt(size_in));
   SOPHUS_ASSERT_EQ(size_in, size_out);
 
   ImageLayout layout_in(size_in, 640);
-  ImageLayout layout_out = fromProto(toProto(layout_in));
+  ImageLayout layout_out = *fromProt(toProt(layout_in));
   SOPHUS_ASSERT_EQ(layout_in, layout_out);
 
   testPixelFormat<float>();
@@ -93,4 +95,4 @@ TEST(conv_image, roundtrip) {
        Eigen::Vector3f::Zero(),
        Eigen::Vector3f(0.1, 0.2, 0.3)});
 }
-}  // namespace sophus::test
+}  // namespace farm_ng::test

--- a/cpp/farm_ng/core/proto_conv/lie/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/lie/CMakeLists.txt
@@ -13,3 +13,8 @@ target_link_libraries(farm_ng_core_proto_conv_lie PUBLIC
   farm_ng_core::farm_ng_core_proto_conv_linalg
   farm_ng_core::farm_ng_core_prototools
 )
+
+farm_ng_add_test(conv
+              PARENT_LIBRARY farm_ng_core_proto_conv_lie
+              LINK_LIBRARIES farm_ng_core_proto_conv_lie
+              LABELS small)

--- a/cpp/farm_ng/core/proto_conv/lie/conv.h
+++ b/cpp/farm_ng/core/proto_conv/lie/conv.h
@@ -15,26 +15,18 @@
 #pragma once
 
 #include "farm_ng/core/lie.pb.h"
+#include "farm_ng/core/proto_conv/proto_conv.h"
 #include "sophus/lie/isometry2.h"
 #include "sophus/lie/isometry3.h"
 #include "sophus/lie/rotation2.h"
 #include "sophus/lie/rotation3.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-sophus::QuaternionF64 fromProto(proto::QuaternionF64 const& proto);
-proto::QuaternionF64 toProto(sophus::QuaternionF64 const& quat);
+FARM_PROTO_CONV_TRAIT(sophus::QuaternionF64, core::proto::QuaternionF64);
+FARM_PROTO_CONV_TRAIT(sophus::Rotation2F64, core::proto::Rotation2F64);
+FARM_PROTO_CONV_TRAIT(sophus::Isometry2F64, core::proto::Isometry2F64);
+FARM_PROTO_CONV_TRAIT(sophus::Rotation3F64, core::proto::Rotation3F64);
+FARM_PROTO_CONV_TRAIT(sophus::Isometry3F64, core::proto::Isometry3F64);
 
-sophus::Rotation2<double> fromProto(proto::Rotation2F64 const& proto);
-proto::Rotation2F64 toProto(sophus::Rotation2<double> const& rotation);
-
-sophus::Isometry2<double> fromProto(proto::Isometry2F64 const& proto);
-proto::Isometry2F64 toProto(sophus::Isometry2<double> const& pose);
-
-Expected<sophus::Rotation3<double>> fromProto(proto::Rotation3F64 const& proto);
-proto::Rotation3F64 toProto(sophus::Rotation3<double> const& rotation);
-
-Expected<sophus::Isometry3<double>> fromProto(proto::Isometry3F64 const& proto);
-proto::Isometry3F64 toProto(sophus::Isometry3<double> const& pose);
-
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/lie/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/lie/conv_test.cpp
@@ -17,3 +17,109 @@
 #include <gtest/gtest.h>
 
 using namespace sophus;
+
+using namespace farm_ng;
+using namespace farm_ng::core;
+
+TEST(conv_quat, unit) {
+  {
+    auto q = QuaternionF64::fromParams({2.0, 3.0, 4.0, 1.0});
+
+    proto::QuaternionF64 proto = toProt(q);
+    EXPECT_EQ(proto.real(), 1);
+    EXPECT_EQ(proto.imag().x(), 2);
+    EXPECT_EQ(proto.imag().y(), 3);
+    EXPECT_EQ(proto.imag().z(), 4);
+    auto maybe_q2 = fromProt(proto);
+    sophus::QuaternionF64 q2 = FARM_UNWRAP(maybe_q2);
+    EXPECT_EQ(q2.real(), q.real());
+    EXPECT_EQ(q2.imag(), q.imag());
+  }
+
+  {
+    auto q = QuaternionF64::zero();
+    proto::QuaternionF64 proto = toProt(q);
+    EXPECT_EQ(proto.real(), 0);
+    EXPECT_EQ(proto.imag().x(), 0);
+    EXPECT_EQ(proto.imag().y(), 0);
+    EXPECT_EQ(proto.imag().z(), 0);
+    auto maybe_q2 = fromProt(proto);
+    sophus::QuaternionF64 q2 = FARM_UNWRAP(maybe_q2);
+    EXPECT_EQ(q2.real(), q.real());
+    EXPECT_EQ(q2.imag(), q.imag());
+  }
+}
+
+TEST(conv_rot, unit) {
+  {
+    auto q = Rotation2F64::fromAngle(1.0);
+    proto::Rotation2F64 proto = toProt(q);
+    EXPECT_EQ(proto.theta(), 1);
+    auto maybe_q2 = fromProt(proto);
+    sophus::Rotation2F64 q2 = FARM_UNWRAP(maybe_q2);
+    EXPECT_EQ(q2.angle(), q.angle());
+  }
+
+  {
+    auto q = sophus::Rotation3F64::elementExamples().at(1);
+    proto::Rotation3F64 proto = toProt(q);
+    EXPECT_EQ(proto.unit_quaternion().real(), q.unitQuaternion().real());
+    EXPECT_EQ(
+        proto.unit_quaternion().imag().x(), q.unitQuaternion().imag().x());
+    EXPECT_EQ(
+        proto.unit_quaternion().imag().y(), q.unitQuaternion().imag().y());
+    EXPECT_EQ(
+        proto.unit_quaternion().imag().z(), q.unitQuaternion().imag().z());
+
+    auto maybe_q2 = fromProt(proto);
+    sophus::Rotation3F64 q2 = FARM_UNWRAP(maybe_q2);
+    EXPECT_EQ(q2.unitQuaternion().real(), q.unitQuaternion().real());
+    EXPECT_EQ(q2.unitQuaternion().imag(), q.unitQuaternion().imag());
+    EXPECT_EQ(q2.params(), q.params());
+    EXPECT_EQ(q2.matrix(), q.matrix());
+
+    proto::Rotation3F64 invalid_proto2;
+
+    auto expect_invalid = fromProt(invalid_proto2);
+    EXPECT_FALSE(expect_invalid);
+  }
+}
+
+TEST(conv_isometry, unit) {
+  {
+    auto iso = sophus::Isometry2F64::elementExamples().at(1);
+    proto::Isometry2F64 proto = toProt(iso);
+    EXPECT_EQ(proto.translation().x(), iso.translation().x());
+    EXPECT_EQ(proto.translation().y(), iso.translation().y());
+    EXPECT_EQ(proto.rotation().theta(), iso.rotation().angle());
+
+    auto maybe_iso2 = fromProt(proto);
+    sophus::Isometry2F64 iso2 = FARM_UNWRAP(maybe_iso2);
+    EXPECT_EQ(iso2.translation(), iso.translation());
+    EXPECT_EQ(iso2.rotation().angle(), iso.rotation().angle());
+  }
+
+  {
+    auto iso = sophus::Isometry3F64::elementExamples().at(1);
+    proto::Isometry3F64 proto = toProt(iso);
+    EXPECT_EQ(proto.translation().x(), iso.translation().x());
+    EXPECT_EQ(proto.translation().y(), iso.translation().y());
+    EXPECT_EQ(proto.translation().z(), iso.translation().z());
+    EXPECT_EQ(
+        proto.rotation().unit_quaternion().real(),
+        iso.rotation().unitQuaternion().real());
+    EXPECT_EQ(
+        proto.rotation().unit_quaternion().imag().x(),
+        iso.rotation().unitQuaternion().imag().x());
+    EXPECT_EQ(
+        proto.rotation().unit_quaternion().imag().y(),
+        iso.rotation().unitQuaternion().imag().y());
+    EXPECT_EQ(
+        proto.rotation().unit_quaternion().imag().z(),
+        iso.rotation().unitQuaternion().imag().z());
+
+    auto maybe_iso2 = fromProt(proto);
+    sophus::Isometry3F64 iso2 = FARM_UNWRAP(maybe_iso2);
+    EXPECT_EQ(iso2.compactMatrix(), iso.compactMatrix());
+  }
+}

--- a/cpp/farm_ng/core/proto_conv/linalg/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/linalg/CMakeLists.txt
@@ -13,3 +13,8 @@ target_link_libraries(farm_ng_core_proto_conv_linalg PUBLIC
   farm_ng_core::farm_ng_core_proto_defs
   farm_ng_core::farm_ng_core_prototools
 )
+
+farm_ng_add_test(conv
+              PARENT_LIBRARY farm_ng_core_proto_conv_linalg
+              LINK_LIBRARIES farm_ng_core_proto_conv_linalg
+              LABELS small)

--- a/cpp/farm_ng/core/proto_conv/linalg/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/linalg/conv.cpp
@@ -14,131 +14,179 @@
 
 #include "farm_ng/core/proto_conv/linalg/conv.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-Eigen::Matrix<uint32_t, 2, 1> fromProto(proto::Vec2I64 const& proto) {
-  return Eigen::Matrix<uint32_t, 2, 1>(proto.x(), proto.y());
+template <>
+auto fromProt<core::proto::Vec2I64>(core::proto::Vec2I64 const& proto)
+    -> Expected<Eigen::Vector2i> {
+  return Eigen::Vector2i(proto.x(), proto.y());
 }
 
-proto::Vec2I64 toProto(Eigen::Matrix<uint32_t, 2, 1> const& v) {
-  proto::Vec2I64 proto;
+template <>
+auto toProt<Eigen::Vector2i>(Eigen::Vector2i const& v) -> core::proto::Vec2I64 {
+  core::proto::Vec2I64 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   return proto;
 }
 
-Eigen::Vector2f fromProto(proto::Vec2F32 const& proto) {
+template <>
+auto fromProt<core::proto::Vec2F32>(core::proto::Vec2F32 const& proto)
+    -> Expected<Eigen::Vector2f> {
   return Eigen::Vector2f(proto.x(), proto.y());
 }
 
-proto::Vec2F32 toProto(Eigen::Vector2f const& v) {
-  proto::Vec2F32 proto;
+template <>
+auto toProt<Eigen::Vector2f>(Eigen::Vector2f const& v) -> core::proto::Vec2F32 {
+  core::proto::Vec2F32 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   return proto;
 }
 
-Eigen::Vector2d fromProto(proto::Vec2F64 const& proto) {
+template <>
+auto fromProt<core::proto::Vec2F64>(core::proto::Vec2F64 const& proto)
+    -> Expected<Eigen::Vector2d> {
   return Eigen::Vector2d(proto.x(), proto.y());
 }
 
-proto::Vec2F64 toProto(Eigen::Vector2d const& v) {
-  proto::Vec2F64 proto;
+template <>
+auto toProt<Eigen::Vector2d>(Eigen::Vector2d const& v) -> core::proto::Vec2F64 {
+  core::proto::Vec2F64 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   return proto;
 }
 
-Eigen::Matrix<uint32_t, 3, 1> fromProto(proto::Vec3I64 const& proto) {
-  return Eigen::Matrix<uint32_t, 3, 1>(proto.x(), proto.y(), proto.z());
+template <>
+auto fromProt<core::proto::Vec3I64>(core::proto::Vec3I64 const& proto)
+    -> Expected<Eigen::Vector3i> {
+  return Eigen::Vector3i(proto.x(), proto.y(), proto.z());
 }
 
-proto::Vec3I64 toProto(Eigen::Matrix<uint32_t, 3, 1> const& v) {
-  proto::Vec3I64 proto;
+template <>
+auto toProt<Eigen::Vector3i>(Eigen::Vector3i const& v) -> core::proto::Vec3I64 {
+  core::proto::Vec3I64 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   proto.set_z(v.z());
   return proto;
 }
 
-Eigen::Vector3f fromProto(proto::Vec3F32 const& proto) {
+template <>
+auto fromProt<core::proto::Vec3F32>(core::proto::Vec3F32 const& proto)
+    -> Expected<Eigen::Vector3f> {
   return Eigen::Vector3f(proto.x(), proto.y(), proto.z());
 }
 
-proto::Vec3F32 toProto(Eigen::Vector3f const& v) {
-  proto::Vec3F32 proto;
+template <>
+auto toProt<Eigen::Vector3f>(Eigen::Vector3f const& v) -> core::proto::Vec3F32 {
+  core::proto::Vec3F32 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   proto.set_z(v.z());
   return proto;
 }
 
-Eigen::Vector3d fromProto(proto::Vec3F64 const& proto) {
+template <>
+auto fromProt<core::proto::Vec3F64>(core::proto::Vec3F64 const& proto)
+    -> Expected<Eigen::Vector3d> {
   return Eigen::Vector3d(proto.x(), proto.y(), proto.z());
 }
 
-proto::Vec3F64 toProto(Eigen::Vector3d const& v) {
-  proto::Vec3F64 proto;
+template <>
+auto toProt<Eigen::Vector3d>(Eigen::Vector3d const& v) -> core::proto::Vec3F64 {
+  core::proto::Vec3F64 proto;
   proto.set_x(v.x());
   proto.set_y(v.y());
   proto.set_z(v.z());
   return proto;
 }
 
-Eigen::Matrix2f fromProto(proto::Mat2F32 const& proto) {
+template <>
+auto fromProt<core::proto::Mat2F32>(core::proto::Mat2F32 const& proto)
+    -> Expected<Eigen::Matrix2f> {
+  FARM_TRY(auto, col0, fromProt(proto.col_0()));
+  FARM_TRY(auto, col1, fromProt(proto.col_1()));
+
   Eigen::Matrix2f m;
-  m.col(0) = fromProto(proto.col_0());
-  m.col(1) = fromProto(proto.col_1());
+  m.col(0) = col0;
+  m.col(1) = col1;
   return m;
 }
-proto::Mat2F32 toProto(Eigen::Matrix2f const& v) {
-  proto::Mat2F32 proto;
-  *proto.mutable_col_0() = toProto(v.col(0).eval());
-  *proto.mutable_col_1() = toProto(v.col(1).eval());
+
+template <>
+auto toProt<Eigen::Matrix2f>(Eigen::Matrix2f const& v) -> core::proto::Mat2F32 {
+  core::proto::Mat2F32 proto;
+  *proto.mutable_col_0() = toProt<Eigen::Vector2f>(v.col(0));
+  *proto.mutable_col_1() = toProt<Eigen::Vector2f>(v.col(1));
   return proto;
 }
 
-Eigen::Matrix2d fromProto(proto::Mat2F64 const& proto) {
+template <>
+auto fromProt<core::proto::Mat2F64>(core::proto::Mat2F64 const& proto)
+    -> Expected<Eigen::Matrix2d> {
+  FARM_TRY(auto, col0, fromProt(proto.col_0()));
+  FARM_TRY(auto, col1, fromProt(proto.col_1()));
+
   Eigen::Matrix2d m;
-  m.col(0) = fromProto(proto.col_0());
-  m.col(1) = fromProto(proto.col_1());
+  m.col(0) = col0;
+  m.col(1) = col1;
   return m;
 }
-proto::Mat2F64 toProto(Eigen::Matrix2d const& v) {
-  proto::Mat2F64 proto;
-  *proto.mutable_col_0() = toProto(v.col(0).eval());
-  *proto.mutable_col_1() = toProto(v.col(1).eval());
+
+template <>
+auto toProt<Eigen::Matrix2d>(Eigen::Matrix2d const& v) -> core::proto::Mat2F64 {
+  core::proto::Mat2F64 proto;
+  *proto.mutable_col_0() = toProt<Eigen::Vector2d>(v.col(0));
+  *proto.mutable_col_1() = toProt<Eigen::Vector2d>(v.col(1));
   return proto;
 }
 
-Eigen::Matrix3f fromProto(proto::Mat3F32 const& proto) {
+template <>
+auto fromProt<core::proto::Mat3F32>(core::proto::Mat3F32 const& proto)
+    -> Expected<Eigen::Matrix3f> {
+  FARM_TRY(auto, col0, fromProt(proto.col_0()));
+  FARM_TRY(auto, col1, fromProt(proto.col_1()));
+  FARM_TRY(auto, col2, fromProt(proto.col_2()));
+
   Eigen::Matrix3f m;
-  m.col(0) = fromProto(proto.col_0());
-  m.col(1) = fromProto(proto.col_1());
-  m.col(2) = fromProto(proto.col_2());
+  m.col(0) = col0;
+  m.col(1) = col1;
+  m.col(2) = col2;
   return m;
 }
-proto::Mat3F32 toProto(Eigen::Matrix3f const& v) {
-  proto::Mat3F32 proto;
-  *proto.mutable_col_0() = toProto(v.col(0).eval());
-  *proto.mutable_col_1() = toProto(v.col(1).eval());
-  *proto.mutable_col_2() = toProto(v.col(2).eval());
+
+template <>
+auto toProt<Eigen::Matrix3f>(Eigen::Matrix3f const& v) -> core::proto::Mat3F32 {
+  core::proto::Mat3F32 proto;
+  *proto.mutable_col_0() = toProt<Eigen::Vector3f>(v.col(0));
+  *proto.mutable_col_1() = toProt<Eigen::Vector3f>(v.col(1));
+  *proto.mutable_col_2() = toProt<Eigen::Vector3f>(v.col(2));
   return proto;
 }
 
-Eigen::Matrix3d fromProto(proto::Mat3F64 const& proto) {
+template <>
+auto fromProt<core::proto::Mat3F64>(core::proto::Mat3F64 const& proto)
+    -> Expected<Eigen::Matrix3d> {
+  FARM_TRY(auto, col0, fromProt(proto.col_0()));
+  FARM_TRY(auto, col1, fromProt(proto.col_1()));
+  FARM_TRY(auto, col2, fromProt(proto.col_2()));
+
   Eigen::Matrix3d m;
-  m.col(0) = fromProto(proto.col_0());
-  m.col(1) = fromProto(proto.col_1());
-  m.col(2) = fromProto(proto.col_2());
+  m.col(0) = col0;
+  m.col(1) = col1;
+  m.col(2) = col2;
   return m;
 }
-proto::Mat3F64 toProto(Eigen::Matrix3d const& v) {
-  proto::Mat3F64 proto;
-  *proto.mutable_col_0() = toProto(v.col(0).eval());
-  *proto.mutable_col_1() = toProto(v.col(1).eval());
-  *proto.mutable_col_2() = toProto(v.col(2).eval());
+
+template <>
+auto toProt<Eigen::Matrix3d>(Eigen::Matrix3d const& v) -> core::proto::Mat3F64 {
+  core::proto::Mat3F64 proto;
+  *proto.mutable_col_0() = toProt<Eigen::Vector3d>(v.col(0));
+  *proto.mutable_col_1() = toProt<Eigen::Vector3d>(v.col(1));
+  *proto.mutable_col_2() = toProt<Eigen::Vector3d>(v.col(2));
   return proto;
 }
 
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/linalg/conv.h
+++ b/cpp/farm_ng/core/proto_conv/linalg/conv.h
@@ -15,39 +15,31 @@
 #pragma once
 
 #include "farm_ng/core/linalg.pb.h"
+#include "farm_ng/core/logging/expected.h"
+#include "farm_ng/core/proto_conv/proto_conv.h"
 
 #include <Eigen/Core>
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-Eigen::Matrix<uint32_t, 2, 1> fromProto(proto::Vec2I64 const& proto);
-proto::Vec2I64 toProto(Eigen::Matrix<uint32_t, 2, 1> const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector2i, core::proto::Vec2I64);
 
-Eigen::Vector2f fromProto(proto::Vec2F32 const& proto);
-proto::Vec2F32 toProto(Eigen::Vector2f const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector2f, core::proto::Vec2F32);
 
-Eigen::Vector2d fromProto(proto::Vec2F64 const& proto);
-proto::Vec2F64 toProto(Eigen::Vector2d const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector2d, core::proto::Vec2F64);
 
-Eigen::Matrix<uint32_t, 3, 1> fromProto(proto::Vec3I64 const& proto);
-proto::Vec3I64 toProto(Eigen::Matrix<uint32_t, 3, 1> const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector3i, core::proto::Vec3I64);
 
-Eigen::Vector3f fromProto(proto::Vec3F32 const& proto);
-proto::Vec3F32 toProto(Eigen::Vector3f const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector3f, core::proto::Vec3F32);
 
-Eigen::Vector3d fromProto(proto::Vec3F64 const& proto);
-proto::Vec3F64 toProto(Eigen::Vector3d const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Vector3d, core::proto::Vec3F64);
 
-Eigen::Matrix2f fromProto(proto::Mat2F32 const& proto);
-proto::Mat2F32 toProto(Eigen::Matrix2f const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Matrix2f, core::proto::Mat2F32);
 
-Eigen::Matrix2d fromProto(proto::Mat2F64 const& proto);
-proto::Mat2F64 toProto(Eigen::Matrix2d const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Matrix2d, core::proto::Mat2F64);
 
-Eigen::Matrix3f fromProto(proto::Mat3F32 const& proto);
-proto::Mat3F32 toProto(Eigen::Matrix3f const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Matrix3f, core::proto::Mat3F32);
 
-Eigen::Matrix3d fromProto(proto::Mat3F64 const& proto);
-proto::Mat3F64 toProto(Eigen::Matrix3d const& v);
+FARM_PROTO_CONV_TRAIT(Eigen::Matrix3d, core::proto::Mat3F64);
 
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/linalg/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/linalg/conv_test.cpp
@@ -16,4 +16,143 @@
 
 #include <gtest/gtest.h>
 
-using namespace sophus;
+using namespace farm_ng;
+using namespace farm_ng::core;
+
+TEST(conv_vec, unit) {
+  {
+    Eigen::Vector2i v(1, 2);
+    proto::Vec2I64 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 1);
+    EXPECT_EQ(proto.y(), 2);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector2i v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Vector2f v(1, 2);
+    proto::Vec2F32 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 1);
+    EXPECT_EQ(proto.y(), 2);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector2f v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Vector2d v(5, 6);
+    proto::Vec2F64 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 5);
+    EXPECT_EQ(proto.y(), 6);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector2d v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Vector3i v(1, 2, 3);
+    proto::Vec3I64 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 1);
+    EXPECT_EQ(proto.y(), 2);
+    EXPECT_EQ(proto.z(), 3);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector3i v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Vector3f v(1, 2, 3);
+    proto::Vec3F32 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 1);
+    EXPECT_EQ(proto.y(), 2);
+    EXPECT_EQ(proto.z(), 3);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector3f v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Vector3d v(1, 2, 3);
+    proto::Vec3F64 proto = toProt(v);
+    EXPECT_EQ(proto.x(), 1);
+    EXPECT_EQ(proto.y(), 2);
+    EXPECT_EQ(proto.z(), 3);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Vector3d v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+}
+
+TEST(conv_mat, unit) {
+  {
+    Eigen::Matrix2f v;
+    v << 1, 2,  //
+        3, 4;
+    proto::Mat2F32 proto = toProt(v);
+    EXPECT_EQ(proto.col_0().x(), 1);
+    EXPECT_EQ(proto.col_1().x(), 2);
+    EXPECT_EQ(proto.col_0().y(), 3);
+    EXPECT_EQ(proto.col_1().y(), 4);
+
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Matrix2f v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Matrix2d v;
+    v << 1, 2,  //
+        3, 4;
+    proto::Mat2F64 proto = toProt(v);
+    EXPECT_EQ(proto.col_0().x(), 1);
+    EXPECT_EQ(proto.col_1().x(), 2);
+    EXPECT_EQ(proto.col_0().y(), 3);
+    EXPECT_EQ(proto.col_1().y(), 4);
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Matrix2d v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Matrix3f v;
+    v << 1, 2, 3,  //
+        4, 5, 6,   //
+        7, 8, 9;
+    proto::Mat3F32 proto = toProt(v);
+    EXPECT_EQ(proto.col_0().x(), 1);
+    EXPECT_EQ(proto.col_1().x(), 2);
+    EXPECT_EQ(proto.col_2().x(), 3);
+    EXPECT_EQ(proto.col_0().y(), 4);
+    EXPECT_EQ(proto.col_1().y(), 5);
+    EXPECT_EQ(proto.col_2().y(), 6);
+    EXPECT_EQ(proto.col_0().z(), 7);
+    EXPECT_EQ(proto.col_1().z(), 8);
+    EXPECT_EQ(proto.col_2().z(), 9);
+
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Matrix3f v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+
+  {
+    Eigen::Matrix3d v;
+    v << 1, 2, 3,  //
+        4, 5, 6,   //
+        7, 8, 9;
+    proto::Mat3F64 proto = toProt(v);
+    EXPECT_EQ(proto.col_0().x(), 1);
+    EXPECT_EQ(proto.col_1().x(), 2);
+    EXPECT_EQ(proto.col_2().x(), 3);
+    EXPECT_EQ(proto.col_0().y(), 4);
+    EXPECT_EQ(proto.col_1().y(), 5);
+    EXPECT_EQ(proto.col_2().y(), 6);
+    EXPECT_EQ(proto.col_0().z(), 7);
+    EXPECT_EQ(proto.col_1().z(), 8);
+    EXPECT_EQ(proto.col_2().z(), 9);
+
+    auto maybe_v2 = fromProt(proto);
+    Eigen::Matrix3d v2 = FARM_UNWRAP(maybe_v2);
+    EXPECT_EQ(v2, v);
+  }
+}

--- a/cpp/farm_ng/core/proto_conv/proto_conv.h
+++ b/cpp/farm_ng/core/proto_conv/proto_conv.h
@@ -1,0 +1,105 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include "farm_ng/core/logging/expected.h"
+
+namespace farm_ng {
+
+/// Trait to associate one concrete Proto type with given C++ type `TCpp`.
+///
+/// Helper trait for the `toProt` function template.
+template <class TCpp>
+struct ToProtoTrait;
+
+/// Trait to associate one concrete Cpp type with given proto type `TProto`.
+///
+/// Helper trait for the `fromProt` function template.
+template <class TProto>
+struct FromProtoTrait;
+
+/// Function template to convert a C++ object to a proto object.
+///
+/// Example:
+///
+///     Eigen::Vector3d v(1, 2, 3);
+///     proto::Vec3F64 proto = toProt(v);
+///
+/// Note: The return type is deduced from the argument type using the
+/// `FromProtoTrait` trait.
+template <class TProto>
+auto fromProt(TProto const& proto)
+    -> Expected<typename FromProtoTrait<TProto>::CppType>;
+
+/// Function template to convert a proto object to a C++ object.
+///
+/// Example:
+///
+///     proto::Vec3F64 proto;
+///     proto.set_x(1);
+///     proto.set_y(2);
+///     proto.set_z(3);
+///     Eigen::Vector3d v = fromProt(proto);
+///
+/// Note: The return type is deduced from the argument type using the
+/// `ToProtoTrait` trait.
+template <class TCpp>
+auto toProt(TCpp const& cpp) -> typename ToProtoTrait<TCpp>::ProtoType;
+
+/// Convenience macro to define the `ToProtoTrait` and `FromProtoTrait` as well
+/// as the `toProt` and `fromProt` function templates instantiation declarations
+/// for a given C++ type `TCpp` and a given proto type `TProto`. Hence, this
+/// macro is typically used in a header file.
+///
+/// Example:
+///
+///     FARM_PROTO_CONV_TRAIT(Eigen::Vector3d, proto::Vec3F64);
+///
+/// produces the following code:
+///
+///     template <>
+///     struct ToProtoTrait<Eigen::Vector3d> {
+///       using ProtoType = proto::Vec3F64;
+///     };
+///
+///     template <>
+///     struct FromProtoTrait<proto::Vec3F64> {
+///       using CppType = Eigen::Vector3d;
+///     };
+///
+///     template <>
+///     auto fromProt<proto::Vec3F64>(proto::Vec3F64 const& proto)
+///         -> Expected<Eigen::Vector3d>;
+///
+///     template <>
+///     auto toProt<Eigen::Vector3d>(Eigen::Vector3d const& cpp)
+///         -> proto::Vec3F64;
+///
+#define FARM_PROTO_CONV_TRAIT(TCpp, TProto)                   \
+  template <>                                                 \
+  struct ToProtoTrait<TCpp> {                                 \
+    using ProtoType = TProto;                                 \
+  };                                                          \
+  template <>                                                 \
+  struct FromProtoTrait<TProto> {                             \
+    using CppType = TCpp;                                     \
+  };                                                          \
+  template <>                                                 \
+  auto fromProt<TProto>(TProto const& proto)->Expected<TCpp>; \
+                                                              \
+  template <>                                                 \
+  auto toProt<TCpp>(TCpp const& cpp)->TProto
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/sensor/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/sensor/CMakeLists.txt
@@ -13,3 +13,9 @@ target_link_libraries(farm_ng_core_proto_conv_sensor PUBLIC
   farm_ng_core::farm_ng_core_prototools
   farm_ng_core::farm_ng_core_proto_conv_image
 )
+
+
+farm_ng_add_test(conv
+              PARENT_LIBRARY farm_ng_core_proto_conv_sensor
+              LINK_LIBRARIES farm_ng_core_proto_conv_sensor
+              LABELS small)

--- a/cpp/farm_ng/core/proto_conv/sensor/conv.h
+++ b/cpp/farm_ng/core/proto_conv/sensor/conv.h
@@ -14,17 +14,14 @@
 
 #pragma once
 
+#include "farm_ng/core/proto_conv/proto_conv.h"
 #include "farm_ng/core/sensor.pb.h"
 #include "sophus/sensor/camera_model.h"
 
-namespace farm_ng::core {
+namespace farm_ng {
 
-Expected<sophus::CameraModel> fromProto(proto::CameraModel const& proto);
-proto::CameraModel toProto(sophus::CameraModel const& camera_model);
+FARM_PROTO_CONV_TRAIT(sophus::CameraModel, core::proto::CameraModel);
+FARM_PROTO_CONV_TRAIT(
+    std::vector<sophus::CameraModel>, core::proto::CameraModels);
 
-Expected<std::vector<sophus::CameraModel>> fromProto(
-    proto::CameraModels const& proto);
-proto::CameraModels toProto(
-    std::vector<sophus::CameraModel> const& camera_models);
-
-}  // namespace farm_ng::core
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/sensor/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/sensor/conv_test.cpp
@@ -12,8 +12,48 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "sophus/sensor/proto/conv.h"
+#include "farm_ng/core/proto_conv/sensor/conv.h"
 
 #include <gtest/gtest.h>
 
 using namespace sophus;
+
+using namespace farm_ng;
+using namespace farm_ng::core;
+
+TEST(conv_sensor, unit) {
+  {
+    sophus::CameraModel pinhole = createDefaultPinholeModel({64, 24});
+    proto::CameraModel proto = toProt(pinhole);
+    EXPECT_EQ(proto.image_size().width(), 64);
+    EXPECT_EQ(proto.image_size().height(), 24);
+    EXPECT_EQ(proto.distortion_type(), toString(pinhole.distortionType()));
+    ASSERT_EQ(proto.params().size(), pinhole.params().size());
+    for (int i = 0; i < proto.params().size(); ++i) {
+      EXPECT_EQ(proto.params(i), pinhole.params()(i));
+    }
+
+    auto maybe_pinhole2 = fromProt(proto);
+    sophus::CameraModel pinhole2 = FARM_UNWRAP(maybe_pinhole2);
+    EXPECT_EQ(pinhole2.imageSize(), pinhole.imageSize());
+    ASSERT_EQ(pinhole2.params(), pinhole.params());
+    EXPECT_EQ(pinhole2.distortionType(), pinhole.distortionType());
+  }
+
+  {
+    std::vector<sophus::CameraModel> models;
+    models.push_back(createDefaultPinholeModel({64, 24}));
+    models.push_back(createDefaultOrthoModel({128, 48}));
+    proto::CameraModels proto = toProt(models);
+    ASSERT_EQ(proto.camera_models_size(), models.size());
+
+    auto maybe_models2 = fromProt(proto);
+    std::vector<sophus::CameraModel> models2 = FARM_UNWRAP(maybe_models2);
+    ASSERT_EQ(models2.size(), models.size());
+    for (size_t i = 0; i < models.size(); ++i) {
+      EXPECT_EQ(models2[i].imageSize(), models[i].imageSize());
+      ASSERT_EQ(models2[i].params(), models[i].params());
+      EXPECT_EQ(models2[i].distortionType(), models[i].distortionType());
+    }
+  }
+}

--- a/farm_ng_core.code-workspace
+++ b/farm_ng_core.code-workspace
@@ -4,5 +4,9 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"files.associations": {
+			"*.ipp": "cpp"
+		}
+	}
 }


### PR DESCRIPTION
 - [x] use specialization instead of ADL for proto conversion to enable more general purpose serialization tools
     E.g. a event logger and playback tools which can deals with all Cpp types which are convertiable to / from Protos.
     _Note: If conversion is done using free functions with argument dependent lookup (ADL), all corresponding header need to be included for such tool. If on the other hand function template specialization is used, only the base case of the template definition needs to be included, and only in the context the template is instantiated, the conversion for the concrete type is required._
 - [x] unit tests for all proto conversions