### PR TITLE
Ensure a request_reply_handler that expects decode is processed correctly

### DIFF
--- a/py/farm_ng/core/event_service.py
+++ b/py/farm_ng/core/event_service.py
@@ -147,7 +147,7 @@ class EventServiceGrpc:
     @request_reply_handler.setter
     def request_reply_handler(self, handler: Callable) -> None:
         """Sets the request/reply handler."""
-        self._request_reply_handler = handler
+        self.add_request_reply_handler(handler)
 
     def add_request_reply_handler(self, handler: Callable) -> None:
         """Sets the request/reply handler."""


### PR DESCRIPTION
As it stands currently, a user could use the `@request_reply_handler.setter` for a handler that either expects decoded messages or does not. But it skips the logic of setting the `_decode_request_reply_handler_message` bool, so this is a high risk for user error 