### PR TITLE
Try revive macos-latest build -- fails for pybind code

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -28,8 +28,10 @@ jobs:
       run: |
         # Install GCC on macOS
         brew install gcc@11
-        export "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
-        export "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
+        # export "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
+        # export "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
+        export CC=/usr/local/bin/gcc-11
+        export CXX=/usr/local/bin/g++-11
         # Run install_deps_mac.sh for macOS
         chmod +x scripts/install_deps_mac.sh
         ./scripts/install_deps_mac.sh

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: pip3 install -e .[dev]
+      run: pip3 install -vvv -e .[dev]
     - name: Run sequential tests
       run: ./run_python_tests.sh
     - name: Run asyncio tests

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -23,20 +23,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Setup and Configure for macOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        # Install GCC on macOS
-        brew install gcc@11
-        # export "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
-        # export "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
-        export CC=/usr/local/bin/gcc-11
-        export CXX=/usr/local/bin/g++-11
-        # Run install_deps_mac.sh for macOS
-        chmod +x scripts/install_deps_mac.sh
-        ./scripts/install_deps_mac.sh
-        # Configure CMake with GCC for macOS
-        cmake -S . -B build -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="-std=c++17"
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run sequential tests

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest ] # macos not supported yet macos-latest
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
@@ -23,6 +23,18 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+- name: Setup and Configure for macOS
+  if: matrix.os == 'macos-latest'
+  run: |
+    # Install GCC on macOS
+    brew install gcc
+    echo "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
+    echo "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
+    # Run install_deps_mac.sh for macOS
+    chmod +x scripts/install_deps_mac.sh
+    ./scripts/install_deps_mac.sh
+    # Configure CMake with GCC for macOS
+    cmake -S . -B build -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="-std=c++17"
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run sequential tests

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -23,18 +23,18 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-- name: Setup and Configure for macOS
-  if: matrix.os == 'macos-latest'
-  run: |
-    # Install GCC on macOS
-    brew install gcc
-    echo "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
-    echo "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
-    # Run install_deps_mac.sh for macOS
-    chmod +x scripts/install_deps_mac.sh
-    ./scripts/install_deps_mac.sh
-    # Configure CMake with GCC for macOS
-    cmake -S . -B build -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="-std=c++17"
+    - name: Setup and Configure for macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        # Install GCC on macOS
+        brew install gcc
+        echo "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
+        # Run install_deps_mac.sh for macOS
+        chmod +x scripts/install_deps_mac.sh
+        ./scripts/install_deps_mac.sh
+        # Configure CMake with GCC for macOS
+        cmake -S . -B build -D CMAKE_C_COMPILER=$CC -D CMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="-std=c++17"
     - name: Install dependencies
       run: pip3 install -e .[dev]
     - name: Run sequential tests

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         # Install GCC on macOS
         brew install gcc
-        echo "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
-        echo "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')" >> $GITHUB_ENV
+        export "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
+        export "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
         # Run install_deps_mac.sh for macOS
         chmod +x scripts/install_deps_mac.sh
         ./scripts/install_deps_mac.sh

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -27,7 +27,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         # Install GCC on macOS
-        brew install gcc
+        brew install gcc@11
         export "CC=$(brew --prefix gcc)/bin/gcc-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
         export "CXX=$(brew --prefix gcc)/bin/g++-$(brew info --json=v1 gcc | jq -r '.[0].installed[0].version')"
         # Run install_deps_mac.sh for macOS

--- a/scripts/install_deps_mac.sh
+++ b/scripts/install_deps_mac.sh
@@ -5,27 +5,18 @@ set -e # exit on error
 
 brew install --verbose \
     assimp \
-    boost \
     catch2 \
     ccache \
-    ceres-solver \
-    cli11 \
-    eigen \
     ffmpeg \
-    fmt \
     glew \
     glog \
-    grpc \
     libjpeg \
     libpng \
     libtiff \
     lz4 \
     ninja \
-    nlohmann-json \
     opencv \
     openexr \
     openssl \
     pre-commit \
-    protobuf \
-    tl-expected \
     zstd

--- a/scripts/install_deps_mac.sh
+++ b/scripts/install_deps_mac.sh
@@ -5,18 +5,27 @@ set -e # exit on error
 
 brew install --verbose \
     assimp \
+    boost \
     catch2 \
     ccache \
+    ceres-solver \
+    cli11 \
+    eigen \
     ffmpeg \
+    fmt \
     glew \
     glog \
+    grpc \
     libjpeg \
     libpng \
     libtiff \
     lz4 \
     ninja \
+    nlohmann-json \
     opencv \
     openexr \
     openssl \
     pre-commit \
+    protobuf \
+    tl-expected \
     zstd

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import os
+import sys
 from pathlib import Path
 
 from farm_ng.package.commands import (
@@ -12,12 +12,26 @@ from setuptools import setup
 
 __version__ = "0.1.0"
 
+
+platform_cxx_flags = []
+
+if sys.platform.startswith("darwin"):
+    print("Running on macOS")
+    platform_cxx_flags = [
+        "-std=c++20",
+    ]
+elif sys.platform.startswith("linux"):
+    print("Running on Linux")
+    platform_cxx_flags = [
+        "-std=gnu++17",
+        "-fconcepts",
+    ]
+else:
+    print("Running on another operating system")
+
 PROTO_ROOT: str = "protos"
 PACKAGE_ROOT: str = "py"
 
-# Set environment variables to specify the GCC compiler
-os.environ["CC"] = "gcc"
-os.environ["CXX"] = "g++"
 
 BuildProtosDevelop.user_options.append(("proto-root=", None, PROTO_ROOT))
 BuildProtosDevelop.user_options.append(("package-root=", None, PACKAGE_ROOT))
@@ -67,12 +81,11 @@ ext_modules = [
         ],
         define_macros=[("VERSION_INFO", __version__)],
         extra_compile_args=[
-            "-fconcepts",
+            *platform_cxx_flags,
             "-Wall",
             "-Wextra",
             "-Werror",
             "-Wno-unused-parameter",
-            "-std=gnu++17",
             "-Wno-missing-field-initializers",
             "-Wno-unused-but-set-variable",
             "-Wno-unused-variable",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ platform_cxx_flags = []
 
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
-    platform_cxx_flags = ["-mmacosx-version-min=10.15"]
+    platform_cxx_flags = ["-std=gnu++17", "-fconcepts", "-mmacosx-version-min=11"]
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
 
 elif sys.platform.startswith("linux"):

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,7 @@ platform_cxx_flags = []
 
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
-    platform_cxx_flags = [
-        "-std=c++20",
-    ]
+    platform_cxx_flags = ["-std=c++20", "-stdlib=libc++"]
 elif sys.platform.startswith("linux"):
     print("Running on Linux")
     platform_cxx_flags = [

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ platform_cxx_flags = []
 
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
-    platform_cxx_flags = ["-std=c++20", "-stdlib=libc++", "-mmacosx-version-min=10.15"]
-    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
+    platform_cxx_flags = ["-mmacosx-version-min=10.15"]
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
 
 elif sys.platform.startswith("linux"):
     print("Running on Linux")

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ ext_modules = [
             "-Wall",
             "-Wextra",
             "-Werror",
+            "-Wno-unknown-warning-option",
             "-Wno-unused-parameter",
             "-Wno-missing-field-initializers",
             "-Wno-unused-but-set-variable",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 
@@ -17,7 +18,9 @@ platform_cxx_flags = []
 
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
-    platform_cxx_flags = ["-std=c++20", "-stdlib=libc++"]
+    platform_cxx_flags = ["-std=c++20", "-stdlib=libc++", "-mmacosx-version-min=10.15"]
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = 10.15
+
 elif sys.platform.startswith("linux"):
     print("Running on Linux")
     platform_cxx_flags = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ platform_cxx_flags = []
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
     platform_cxx_flags = ["-std=c++20", "-stdlib=libc++", "-mmacosx-version-min=10.15"]
-    os.environ["MACOSX_DEPLOYMENT_TARGET"] = 10.15
+    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
 
 elif sys.platform.startswith("linux"):
     print("Running on Linux")

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from farm_ng.package.commands import (
@@ -13,6 +14,10 @@ __version__ = "0.1.0"
 
 PROTO_ROOT: str = "protos"
 PACKAGE_ROOT: str = "py"
+
+# Set environment variables to specify the GCC compiler
+os.environ["CC"] = "gcc"
+os.environ["CXX"] = "g++"
 
 BuildProtosDevelop.user_options.append(("proto-root=", None, PROTO_ROOT))
 BuildProtosDevelop.user_options.append(("package-root=", None, PACKAGE_ROOT))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ platform_cxx_flags = []
 
 if sys.platform.startswith("darwin"):
     print("Running on macOS")
-    platform_cxx_flags = ["-std=gnu++17", "-fconcepts", "-mmacosx-version-min=11"]
+    platform_cxx_flags = [
+        "-std=c++20",
+        "-mmacosx-version-min=11.0",
+        "-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS=1",
+    ]
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
 
 elif sys.platform.startswith("linux"):


### PR DESCRIPTION
Attempt at reviving the ability to pip install on a `macos-latest` runner. Spun off from #169, which was split into two so we can separate the #170  from the more difficult problem of reviving the macos build.