### PR TITLE
Attempted fix for install of header-only libraries

### DIFF
--- a/cmake/farm_ng_add_library.cmake
+++ b/cmake/farm_ng_add_library.cmake
@@ -47,24 +47,21 @@ macro(farm_ng_add_library target)
       "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/${abs_include}>"
       "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-  foreach ( file ${FARM_NG_ARGS_HEADERS} )
-
-    if(IS_ABSOLUTE ${file})
-      file(RELATIVE_PATH rel ${CMAKE_SOURCE_DIR}/${abs_include} ${file})
-    else()
-      file(RELATIVE_PATH rel ${CMAKE_SOURCE_DIR}/${abs_include} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
-    endif()
-    #message(STATUS "header: ${file}")
-    #message(STATUS "header rel: ${rel}")
-
-    get_filename_component( dir ${rel} DIRECTORY )
-    # message(STATUS "${FARM_NG_ARGS_INCLUDE_DIR} ${file} ${rel} ${dir}")
-    install( FILES ${file}
-       DESTINATION include/${dir}
-       COMPONENT Devel)
-  endforeach()
-
   if(DEFINED FARM_NG_ARGS_SOURCES)
+    foreach ( file ${FARM_NG_ARGS_HEADERS} )
+
+      if(IS_ABSOLUTE ${file})
+        file(RELATIVE_PATH rel ${CMAKE_SOURCE_DIR}/${abs_include} ${file})
+      else()
+        file(RELATIVE_PATH rel ${CMAKE_SOURCE_DIR}/${abs_include} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+      endif()
+
+      get_filename_component( dir ${rel} DIRECTORY )
+      install( FILES ${file}
+          DESTINATION include/${dir}
+          COMPONENT Devel)
+    endforeach()
+
     string(REPLACE "." ";" VERSION_LIST ${PROJECT_VERSION})
     list(GET VERSION_LIST 0 VERSION_MAJOR)
     list(GET VERSION_LIST 1 VERSION_MINOR)


### PR DESCRIPTION
When trying to invoke a `make install` with a medium-sized parent project (path is redacted here as `<...>`) I encountered the following error, related to the header-only "core/struct" library:
 
```
CMake Error at <...>/farm_ng_core/cpp/farm_ng/core/struct/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "<...>/farm_ng_core/cpp/farm_ng/core/struct/base":
  No such file or directory.
Call Stack (most recent call first):
  <...>/farm_ng_core/cpp/farm_ng/core/cmake_install.cmake:57 (include)
  <...>/farm_ng_core/cpp/cmake_install.cmake:52 (include)
  <...>/farm_ng_core/cmake_install.cmake:57 (include)
  cmake_install.cmake:47 (include)
```

This attempted fix puts more of the install logic behind the condition that we're building a library with headers + sources.

It works for my specific use case; admittedly I have not made the effort to understand all of the surrounding logic in this macro.