### PR TITLE
Add a method for pixel size in sophus::ImageView

### DIFF
--- a/cpp/sophus/image/image_view.h
+++ b/cpp/sophus/image/image_view.h
@@ -94,6 +94,7 @@ struct ImageView {
   [[nodiscard]] auto sizeBytes() const -> size_t {
     return layout().sizeBytes();
   }
+  [[nodiscard]] auto pixelSize() const -> size_t { return sizeof(Pixel); }
 
   /// Returns true if u is in [0, width).
   [[nodiscard]] auto colInBounds(int u) const -> bool {


### PR DESCRIPTION
The `ImageView::sizeBytes()` method uses the original `ImageLayout` structure when using `subview()` results in an inaccurate calculation for the size of the subview. The `ImageLayout` needs be the same in the subview to enable proper indexing into the subview, but this results in calculating the size in bytes incorrectly for the subview. This method exposes the pixel size so it can be calculated correctly for the subview when necessary.