### PR TITLE
Add mypy to pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,12 @@ repos:
       - id: check-yaml
       - id: check-json
         exclude: docs/.*$
-
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.5.1"
+    hooks:
+      - id: mypy
+        args: ["--check-untyped-defs", "--ignore-missing-imports", "--explicit-package-bases"]
+        additional_dependencies: ["types-protobuf", "types-requests"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13
     hooks:

--- a/py/tests/_asyncio/test_event_client.py
+++ b/py/tests/_asyncio/test_event_client.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
 import pytest
-from farm_ng.core.event_client import EventClient
-from farm_ng.core.event_pb2 import Event
-from farm_ng.core.event_service import EventServiceGrpc
-from farm_ng.core.event_service_pb2 import (
-    RequestReplyRequest,
-)
 from google.protobuf.empty_pb2 import Empty
-from google.protobuf.message import Message
 from google.protobuf.wrappers_pb2 import Int32Value, StringValue
+
+if TYPE_CHECKING:
+    from farm_ng.core.event_client import EventClient
+    from farm_ng.core.event_pb2 import Event
+    from farm_ng.core.event_service import EventServiceGrpc
+    from farm_ng.core.event_service_pb2 import (
+        RequestReplyRequest,
+    )
+    from google.protobuf.message import Message
 
 
 class TestEventClient:
@@ -74,7 +79,7 @@ class TestEventClient:
     ) -> None:
         async def request_reply_handler(
             request: RequestReplyRequest,
-        ) -> Message:
+        ) -> Message | None:
             if request.event.uri.path == "/get_foo":
                 return StringValue(value="foo")
             if request.event.uri.path == "/get_bar":


### PR DESCRIPTION
So we can more easily catch failures before they fail in the python CI tests (as in https://github.com/farm-ng/farm-ng-core/actions/runs/7145349070/job/19460834139?pr=196)