### PR TITLE
test_event_service_recorder confirm actually receiving message

### DIFF
--- a/py/tests/_asyncio/test_event_service_recorder.py
+++ b/py/tests/_asyncio/test_event_service_recorder.py
@@ -75,9 +75,12 @@ class TestEventServiceRecorder:
         reader = EventsFileReader(file_name_bin)
         assert reader.open()
 
+        received_msg: bool = False
         for event_log in reader.get_index():
             event_message = event_log.read_message()
             assert event_message == message
+            received_msg = True
+        assert received_msg
 
 
 class TestRecorderService:


### PR DESCRIPTION
When running the asyncio tests locally and add a try / catch I see we have an error:

```bash
exception: Task <Task pending name='Task-21' coro=<EventServiceRecorder.record() running at /home/kyle/farm-ng/workspace/farm_ng_core/py/farm_ng/core/event_service_recorder.py:149> cb=[gather.<locals>._done_callback() at /usr/lib/python3.8/asyncio/tasks.py:769]> got Future <Future pending> attached to a different loop
```

corresponding to the line in `EventServiceRecorder`:
```bash
                event, payload = await self.record_queue.get()
```