### PR TITLE
Add docformatter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,8 @@ repos:
       - id: ruff
         exclude: (thirdparty|cpp/sophus)/.*$
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/myint/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,7 +88,7 @@ repos:
       - id: ruff
         exclude: (thirdparty|cpp/sophus)/.*$
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/myint/docformatter
+  - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.5
     hooks:
       - id: docformatter

--- a/cpp/sophus/sympy/sophus/affine_camera.py
+++ b/cpp/sophus/sympy/sophus/affine_camera.py
@@ -11,7 +11,7 @@ from sophus.matrix import vector3
 
 
 class AffineCamera:
-    """Affine camera transform"""
+    """Affine camera transform."""
 
     def __init__(self, focal_length, center):
         assert isinstance(focal_length, sympy.Matrix)
@@ -22,7 +22,7 @@ class AffineCamera:
         self.center = center
 
     def pixel_from_z1_plane(self, point_in_camera_z1_plane):
-        """Map point from z1-plane to"""
+        """Map point from z1-plane to."""
         assert isinstance(point_in_camera_z1_plane, sympy.Matrix)
         assert point_in_camera_z1_plane.shape == (
             2,

--- a/cpp/sophus/sympy/sophus/brown_conrady_camera.py
+++ b/cpp/sophus/sympy/sophus/brown_conrady_camera.py
@@ -12,7 +12,7 @@ from sophus.matrix import vector8
 
 
 class BrownConradyCamera:
-    """Brown Conrady camera transform"""
+    """Brown Conrady camera transform."""
 
     def __init__(self, focal_length, center, distortion):
         assert isinstance(focal_length, sympy.Matrix)

--- a/cpp/sophus/sympy/sophus/complex.py
+++ b/cpp/sophus/sympy/sophus/complex.py
@@ -5,14 +5,14 @@ import sympy
 
 
 class Complex:
-    """Complex class"""
+    """Complex class."""
 
     def __init__(self, real, imag):
         self.real = real
         self.imag = imag
 
     def __mul__(self, right):
-        """complex multiplication"""
+        """Complex multiplication."""
         return Complex(
             self.real * right.real - self.imag * right.imag,
             self.imag * right.real + self.real * right.imag,
@@ -34,15 +34,15 @@ class Complex:
         return self.imag
 
     def squared_norm(self):
-        """squared norm when considering the complex number as tuple"""
+        """Squared norm when considering the complex number as tuple."""
         return self.real**2 + self.imag**2
 
     def conj(self):
-        """complex conjugate"""
+        """Complex conjugate."""
         return Complex(self.real, -self.imag)
 
     def inv(self):
-        """complex inverse"""
+        """Complex inverse."""
         return Complex(
             self.conj().real / self.squared_norm(),
             self.conj().imag / self.squared_norm(),
@@ -75,12 +75,12 @@ class Complex:
 
     @staticmethod
     def da_a_mul_b(_a, b):
-        """derivative of complex multiplication wrt left multiplier a"""
+        """Derivative of complex multiplication wrt left multiplier a."""
         return sympy.Matrix([[b.real, -b.imag], [b.imag, b.real]])
 
     @staticmethod
     def db_a_mul_b(a, _b):
-        """derivative of complex multiplication wrt right multiplicand b"""
+        """Derivative of complex multiplication wrt right multiplicand b."""
         return sympy.Matrix([[a.real, -a.imag], [a.imag, a.real]])
 
 

--- a/cpp/sophus/sympy/sophus/dual_quaternion.py
+++ b/cpp/sophus/sympy/sophus/dual_quaternion.py
@@ -8,23 +8,22 @@ from sophus.quaternion import Quaternion
 
 
 class DualQuaternion:
-    """Dual quaternion class"""
+    """Dual quaternion class."""
 
     def __init__(self, real_q, inf_q):
-        """Dual quaternion consists of a real quaternion, and an infinitesimal
-        quaternion"""
+        """Dual quaternion consists of a real quaternion, and an infinitesimal quaternion."""
         self.real_q = real_q
         self.inf_q = inf_q
 
     def __mul__(self, right):
-        """dual quaternion multiplication"""
+        """Dual quaternion multiplication."""
         return DualQuaternion(
             self.real_q * right.real_q,
             self.real_q * right.inf_q + self.inf_q * right.real_q,
         )
 
     def __truediv__(self, scalar):
-        """scalar division"""
+        """Scalar division."""
         return DualQuaternion(self.real_q / scalar, self.inf_q / scalar)
 
     def __repr__(self):
@@ -37,15 +36,15 @@ class DualQuaternion:
         return self.inf_q[key - 4]
 
     def squared_norm(self):
-        """squared norm when considering the dual quaternion as 8-tuple"""
+        """Squared norm when considering the dual quaternion as 8-tuple."""
         return self.real_q.squared_norm() + self.inf_q.squared_norm()
 
     def conj(self):
-        """dual quaternion conjugate"""
+        """Dual quaternion conjugate."""
         return DualQuaternion(self.real_q.conj(), self.inf_q.conj())
 
     def inv(self):
-        """dual quaternion inverse"""
+        """Dual quaternion inverse."""
         return DualQuaternion(
             self.real_q.inv(), -self.real_q.inv() * self.inf_q * self.real_q.inv()
         )

--- a/cpp/sophus/sympy/sophus/inverse_depth.py
+++ b/cpp/sophus/sympy/sophus/inverse_depth.py
@@ -27,7 +27,7 @@ def translation():
 
 
 class InverseDepth:
-    """Affine camera transform"""
+    """Affine camera transform."""
 
     def __init__(self, ab_and_psi):
         assert isinstance(ab_and_psi, sympy.Matrix)

--- a/cpp/sophus/sympy/sophus/kannala_brandt_camera.py
+++ b/cpp/sophus/sympy/sophus/kannala_brandt_camera.py
@@ -15,7 +15,7 @@ init_printing(use_latex="mathjax")
 
 
 class KannalaBrandtTransformCamera:
-    """KannalaBrandt camera transform"""
+    """KannalaBrandt camera transform."""
 
     def __init__(self, focal_length, center, distortion):
         assert isinstance(focal_length, sympy.Matrix)

--- a/cpp/sophus/sympy/sophus/quaternion.py
+++ b/cpp/sophus/sympy/sophus/quaternion.py
@@ -9,31 +9,31 @@ from sophus.matrix import squared_norm
 
 
 class Quaternion:
-    """Quaternion class"""
+    """Quaternion class."""
 
     def __init__(self, real, vec):
-        """Quaternion consists of a real scalar, and an imaginary 3-vector"""
+        """Quaternion consists of a real scalar, and an imaginary 3-vector."""
         assert isinstance(vec, sympy.Matrix)
         assert vec.shape == (3, 1), vec.shape
         self.real = real
         self.vec = vec
 
     def __mul__(self, right):
-        """quaternion multiplication"""
+        """Quaternion multiplication."""
         return Quaternion(
             self[3] * right[3] - self.vec.dot(right.vec),
             self[3] * right.vec + right[3] * self.vec + self.vec.cross(right.vec),
         )
 
     def __add__(self, right):
-        """quaternion multiplication"""
+        """Quaternion multiplication."""
         return Quaternion(self[3] + right[3], self.vec + right.vec)
 
     def __neg__(self):
         return Quaternion(-self[3], -self.vec)
 
     def __truediv__(self, scalar):
-        """scalar division"""
+        """Scalar division."""
         return Quaternion(self.real / scalar, self.vec / scalar)
 
     def __repr__(self):
@@ -47,15 +47,15 @@ class Quaternion:
         return self.vec[key]
 
     def squared_norm(self):
-        """squared norm when considering the quaternion as 4-tuple"""
+        """Squared norm when considering the quaternion as 4-tuple."""
         return squared_norm(self.vec) + self.real**2
 
     def conj(self):
-        """quaternion conjugate"""
+        """Quaternion conjugate."""
         return Quaternion(self.real, -self.vec)
 
     def inv(self):
-        """quaternion inverse"""
+        """Quaternion inverse."""
         return self.conj() / self.squared_norm()
 
     @staticmethod
@@ -87,7 +87,7 @@ class Quaternion:
 
     @staticmethod
     def da_a_mul_b(_a, b):
-        """derivative of quaternion multiplication wrt left multiplier a"""
+        """Derivative of quaternion multiplication wrt left multiplier a."""
         v0 = b.vec[0]
         v1 = b.vec[1]
         v2 = b.vec[2]
@@ -98,7 +98,7 @@ class Quaternion:
 
     @staticmethod
     def db_a_mul_b(a, _b):
-        """derivative of quaternion multiplication wrt right multiplicand b"""
+        """Derivative of quaternion multiplication wrt right multiplicand b."""
         u0 = a.vec[0]
         u1 = a.vec[1]
         u2 = a.vec[2]

--- a/cpp/sophus/sympy/sophus/se2.py
+++ b/cpp/sophus/sympy/sophus/se2.py
@@ -17,17 +17,16 @@ from sophus.so2 import Rotation2
 
 
 class Isometry2:
-    """2 dimensional group of rigid body transformations"""
+    """2 dimensional group of rigid body transformations."""
 
     def __init__(self, so2, t):
-        """internally represented by a unit complex number z and a translation
-        2-vector"""
+        """Internally represented by a unit complex number z and a translation 2-vector."""
         self.so2 = so2
         self.t = t
 
     @staticmethod
     def exp(v):
-        """exponential map"""
+        """Exponential map."""
         theta = v[2]
         so2 = Rotation2.exp(theta)
 
@@ -62,13 +61,12 @@ class Isometry2:
         return Rotation2.hat(theta).row_join(upsilon).col_join(sympy.Matrix.zeros(1, 3))
 
     def matrix(self):
-        """returns matrix representation"""
+        """Returns matrix representation."""
         mat_r = self.so2.matrix()
         return (mat_r.row_join(self.t)).col_join(sympy.Matrix(1, 3, [0, 0, 1]))
 
     def __mul__(self, right):
-        """left-multiplication
-        either rotation concatenation or point-transform"""
+        """Left-multiplication either rotation concatenation or point-transform."""
         if isinstance(right, sympy.Matrix):
             assert right.shape == (2, 1), right.shape
             return self.so2 * right + self.t

--- a/cpp/sophus/sympy/sophus/se3.py
+++ b/cpp/sophus/sympy/sophus/se3.py
@@ -18,11 +18,10 @@ from sophus.so3 import Rotation3
 
 
 class Isometry3:
-    """3 dimensional group of rigid body transformations"""
+    """3 dimensional group of rigid body transformations."""
 
     def __init__(self, so3, t):
-        """internally represented by a unit quaternion q and a translation
-        3-vector"""
+        """Internally represented by a unit quaternion q and a translation 3-vector."""
         assert isinstance(so3, Rotation3)
         assert isinstance(t, sympy.Matrix)
         assert t.shape == (3, 1), t.shape
@@ -32,7 +31,7 @@ class Isometry3:
 
     @staticmethod
     def exp(v):
-        """exponential map"""
+        """Exponential map."""
         upsilon = v[0:3, :]
         omega = vector3(v[3], v[4], v[5])
         so3 = Rotation3.exp(omega)
@@ -79,17 +78,15 @@ class Isometry3:
 
     @staticmethod
     def hat(v):
-        """mat_r^6 => mat_r^4x4
-        returns 4x4-matrix representation ``mat_omega``"""
+        """mat_r^6 => mat_r^4x4 returns 4x4-matrix representation ``mat_omega``"""
         upsilon = vector3(v[0], v[1], v[2])
         omega = vector3(v[3], v[4], v[5])
         return Rotation3.hat(omega).row_join(upsilon).col_join(sympy.Matrix.zeros(1, 4))
 
     @staticmethod
     def vee(mat_omega):
-        """mat_r^4x4 => mat_r^6
-        returns 6-vector representation of Lie algebra
-        This is the inverse of the hat-operator"""
+        """mat_r^4x4 => mat_r^6 returns 6-vector representation of Lie algebra This is the inverse of the hat-
+        operator."""
 
         head = vector3(mat_omega[0, 3], mat_omega[1, 3], mat_omega[2, 3])
         tail = Rotation3.vee(mat_omega[0:3, 0:3])
@@ -97,13 +94,12 @@ class Isometry3:
         return upsilon_omega
 
     def matrix(self):
-        """returns matrix representation"""
+        """Returns matrix representation."""
         mat_r = self.so3.matrix()
         return (mat_r.row_join(self.t)).col_join(sympy.Matrix(1, 4, [0, 0, 0, 1]))
 
     def __mul__(self, right):
-        """left-multiplication
-        either rotation concatenation or point-transform"""
+        """Left-multiplication either rotation concatenation or point-transform."""
         if isinstance(right, sympy.Matrix):
             assert right.shape == (3, 1), right.shape
             return self.so3 * right + self.t

--- a/cpp/sophus/sympy/sophus/so2.py
+++ b/cpp/sophus/sympy/sophus/so2.py
@@ -12,19 +12,19 @@ from sophus.matrix import zero_vector2
 
 
 class Rotation2:
-    """2 dimensional group of orthogonal matrices with determinant 1"""
+    """2 dimensional group of orthogonal matrices with determinant 1."""
 
     def __init__(self, z):
-        """internally represented by a unit complex number z"""
+        """Internally represented by a unit complex number z."""
         self.z = z
 
     @staticmethod
     def exp(theta):
-        """exponential map"""
+        """Exponential map."""
         return Rotation2(Complex(sympy.cos(theta), sympy.sin(theta)))
 
     def log(self):
-        """logarithmic map"""
+        """Logarithmic map."""
         return sympy.atan2(self.z.imag, self.z.real)
 
     def calc_dx_log_this(self):
@@ -44,12 +44,11 @@ class Rotation2:
         return sympy.Matrix([[0, -theta], [theta, 0]])
 
     def matrix(self):
-        """returns matrix representation"""
+        """Returns matrix representation."""
         return sympy.Matrix([[self.z.real, -self.z.imag], [self.z.imag, self.z.real]])
 
     def __mul__(self, right):
-        """left-multiplication
-        either rotation concatenation or point-transform"""
+        """Left-multiplication either rotation concatenation or point-transform."""
         if isinstance(right, sympy.Matrix):
             assert right.shape == (2, 1), right.shape
             return self.matrix() * right

--- a/cpp/sophus/sympy/sophus/so3.py
+++ b/cpp/sophus/sympy/sophus/so3.py
@@ -12,15 +12,15 @@ from sophus.quaternion import Quaternion
 
 
 class Rotation3:
-    """3 dimensional group of orthogonal matrices with determinant 1"""
+    """3 dimensional group of orthogonal matrices with determinant 1."""
 
     def __init__(self, q):
-        """internally represented by a unit quaternion q"""
+        """Internally represented by a unit quaternion q."""
         self.q = q
 
     @staticmethod
     def exp(v):
-        """exponential map"""
+        """Exponential map."""
         theta_sq = squared_norm(v)
         theta = sympy.sqrt(theta_sq)
         return Rotation3(
@@ -28,7 +28,7 @@ class Rotation3:
         )
 
     def log(self):
-        """logarithmic map"""
+        """Logarithmic map."""
         n = sympy.sqrt(squared_norm(self.q.vec))
         return 2 * sympy.atan(n / self.q.real) / n * self.q.vec
 
@@ -61,9 +61,8 @@ class Rotation3:
 
     @staticmethod
     def vee(mat_omega):
-        """vee-operator
-        It takes the 3x3-matrix representation ``mat_omega`` and maps it to the
-        corresponding vector representation of Lie algebra.
+        """Vee-operator It takes the 3x3-matrix representation ``mat_omega`` and maps it to the corresponding
+        vector representation of Lie algebra.
 
         This is the inverse of the hat-operator, see above.
 
@@ -79,7 +78,7 @@ class Rotation3:
         return v
 
     def matrix(self):
-        """returns matrix representation"""
+        """Returns matrix representation."""
         return sympy.Matrix(
             [
                 [
@@ -101,8 +100,7 @@ class Rotation3:
         )
 
     def __mul__(self, right):
-        """left-multiplication
-        either rotation concatenation or point-transform"""
+        """Left-multiplication either rotation concatenation or point-transform."""
         if isinstance(right, sympy.Matrix):
             assert right.shape == (3, 1), right.shape
             return (self.q * Quaternion(0, right) * self.q.conj()).vec

--- a/py/farm_ng/core/event_client.py
+++ b/py/farm_ng/core/event_client.py
@@ -1,7 +1,5 @@
-"""
-# This will connect to the test_service and print out the messages it receives
-python -m farm_ng.core.event_client --service-config config.json --service-name test_service
-"""
+"""# This will connect to the test_service and print out the messages it receives python -m
+farm_ng.core.event_client --service-config config.json --service-name test_service"""
 from __future__ import annotations
 
 import argparse

--- a/py/farm_ng/core/event_client.py
+++ b/py/farm_ng/core/event_client.py
@@ -1,5 +1,9 @@
-"""# This will connect to the test_service and print out the messages it receives python -m
-farm_ng.core.event_client --service-config config.json --service-name test_service"""
+"""
+Example Usage:
+
+Connect to the test_service and print out the messages it receives:
+$ python -m farm_ng.core.event_client --service-config config.json --service-name test_service
+"""
 from __future__ import annotations
 
 import argparse

--- a/py/farm_ng/core/event_service.py
+++ b/py/farm_ng/core/event_service.py
@@ -1,5 +1,5 @@
-"""
-# Will run an test_service from the config.
+"""# Will run an test_service from the config.
+
 python -m farm_ng.core.event_service --service-config config.json --service-name test_service
 """
 from __future__ import annotations
@@ -265,7 +265,7 @@ class EventServiceGrpc:
         request: SubscribeRequest,
         context: grpc.aio.ServicerContext,
     ) -> AsyncIterator[SubscribeReply]:
-        """Implementation of grpc rpc subscribe"""
+        """Implementation of grpc rpc subscribe."""
 
         if request.uri.path in self._latched_events:
             yield self._latched_events[request.uri.path]

--- a/py/farm_ng/core/event_service.py
+++ b/py/farm_ng/core/event_service.py
@@ -1,6 +1,8 @@
-"""# Will run an test_service from the config.
+"""
+Usage Examples:
 
-python -m farm_ng.core.event_service --service-config config.json --service-name test_service
+Run a test_service from the config:
+$ python -m farm_ng.core.event_service --service-config config.json --service-name test_service
 """
 from __future__ import annotations
 

--- a/py/farm_ng/core/event_service_recorder.py
+++ b/py/farm_ng/core/event_service_recorder.py
@@ -1,9 +1,7 @@
-"""
-# run the event_service which starts a simple test publisher
-python -m farm_ng.core.event_service
-# run the event_recorder which subscribes to the test publisher and records the events to a file
-python -m farm_ng.core.event_service_recorder record --service-config=config.json --config-name=record_all foo
-# note that the config file has an EventServiceConfig with name "record_all" which subscribes to the test publisher
+"""# run the event_service which starts a simple test publisher python -m farm_ng.core.event_service # run the
+event_recorder which subscribes to the test publisher and records the events to a file python -m
+farm_ng.core.event_service_recorder record --service-config=config.json --config-name=record_all foo # note that
+the config file has an EventServiceConfig with name "record_all" which subscribes to the test publisher
 
 # then try playing back log file:
 python -m farm_ng.core.events_file_reader playback foo.0000.bin
@@ -226,10 +224,8 @@ def get_file_name_base() -> str:
 class RecorderService:
     """Service that subscribes to a list of services and records the events to a file.
 
-    This service will record events to a file when it receives a request to start.
-    It will stop recording when it receives a request to stop.
-    It will publish the progress of recording.
-    It will only record one recording at a time.
+    This service will record events to a file when it receives a request to start. It will stop recording when it
+    receives a request to stop. It will publish the progress of recording. It will only record one recording at a time.
     """
 
     def __init__(self, event_service: EventServiceGrpc) -> None:

--- a/py/farm_ng/core/event_service_recorder.py
+++ b/py/farm_ng/core/event_service_recorder.py
@@ -1,19 +1,26 @@
-"""# run the event_service which starts a simple test publisher python -m farm_ng.core.event_service # run the
-event_recorder which subscribes to the test publisher and records the events to a file python -m
-farm_ng.core.event_service_recorder record --service-config=config.json --config-name=record_all foo # note that
-the config file has an EventServiceConfig with name "record_all" which subscribes to the test publisher
+"""EventServiceRecorder and RecorderService.
 
-# then try playing back log file:
-python -m farm_ng.core.events_file_reader playback foo.0000.bin
+Run the event_service which starts a simple test publisher:
+$ python -m farm_ng.core.event_service
 
-# or try running the event_service_recorder in service mode:
-# start the service
-python -m farm_ng.core.event_service_recorder service --service-config config.json --service-name recorder
+Run the event_recorder which subscribes to the test publisher and logs the events to a file:
+$ python -m farm_ng.core.event_service_recorder record --service-config=config.json --config-name=record_all foo
 
-# in a separate terminal, start recording
-python -m farm_ng.core.event_service_recorder start --service-config config.json  --service-name recorder
-# then stop recording
-python -m farm_ng.core.event_service_recorder stop --service-config config.json  --service-name recorder
+NOTE: The config file has an EventServiceConfig with name "record_all" which subscribes to the test publisher
+
+Play back the log file:
+$ python -m farm_ng.core.events_file_reader playback foo.0000.bin
+
+Try running the event_service_recorder in service mode.
+
+Start the service:
+$ python -m farm_ng.core.event_service_recorder service --service-config config.json --service-name recorder
+
+In a separate terminal, start recording:
+$ python -m farm_ng.core.event_service_recorder start --service-config config.json  --service-name recorder
+
+Then stop recording.
+$ python -m farm_ng.core.event_service_recorder stop --service-config config.json  --service-name recorder
 """
 from __future__ import annotations
 
@@ -224,8 +231,10 @@ def get_file_name_base() -> str:
 class RecorderService:
     """Service that subscribes to a list of services and records the events to a file.
 
-    This service will record events to a file when it receives a request to start. It will stop recording when it
-    receives a request to stop. It will publish the progress of recording. It will only record one recording at a time.
+    - This service will record events to a file when it receives a request to start.
+    - It will stop recording when it receives a request to stop.
+    - It will publish the progress of recording.
+    - It will only record one recording at a time.
     """
 
     def __init__(self, event_service: EventServiceGrpc) -> None:

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -25,8 +25,7 @@ __all__ = [
 
 
 def proto_to_json_file(file_path: str | Path, proto_message: Message) -> bool:
-    """
-    Write a proto Message to a JSON file. The parent directory of the file must exist.
+    """Write a proto Message to a JSON file. The parent directory of the file must exist.
 
     Args:
         file_path (str | Path): The path to the JSON file to create / overwrite.
@@ -103,22 +102,22 @@ class EventsFileWriter:
 
     @property
     def max_file_length(self) -> int:
-        """Max file length, in bytes"""
+        """Max file length, in bytes."""
         return self._max_file_length
 
     @property
     def file_idx(self) -> int:
-        """Current file number for this logging session"""
+        """Current file number for this logging session."""
         return self._file_idx
 
     @property
     def file_length(self) -> int:
-        """Current file length, in bytes"""
+        """Current file length, in bytes."""
         return self._file_length
 
     @property
     def file_name(self) -> Path:
-        """Current file name for this logging session"""
+        """Current file name for this logging session."""
         return self._file_base.with_suffix(f".{self.file_idx:04}" + self.extension)
 
     def is_open(self) -> bool:
@@ -136,13 +135,19 @@ class EventsFileWriter:
         self._file_idx += 1
 
     def open(self) -> bool:
-        """Open the file for writing. Return True if successful."""
+        """Open the file for writing.
+
+        Return True if successful.
+        """
         self._file_stream = Path(self.file_name).open("wb")
         self._file_length = 0
         return self.is_open()
 
     def close(self) -> bool:
-        """Close the file. Return True if successful."""
+        """Close the file.
+
+        Return True if successful.
+        """
         if self.is_closed():
             return True
         file_stream = cast(IO, self._file_stream)

--- a/py/farm_ng/core/stamp.py
+++ b/py/farm_ng/core/stamp.py
@@ -16,11 +16,10 @@ time_source = time
 
 @dataclass
 class StampSemantics:
-    """
-    Recommended semantics for timestamp_pb2.Timestamp timestamps.
+    """Recommended semantics for timestamp_pb2.Timestamp timestamps.
 
-    Example usage for when a device driver (service) receives a message from a device (e.g., a camera):
-        stamp = get_monotonic_now(StampSemantics.DRIVER_RECEIVE)
+    Example usage for when a device driver (service) receives a message from a device (e.g., a camera):     stamp =
+    get_monotonic_now(StampSemantics.DRIVER_RECEIVE)
     """
 
     # When a gRPC client receives a message from a gRPC server.
@@ -72,8 +71,7 @@ def get_stamp_by_semantics_and_clock_type(
     semantics: str,
     clock_type: str,
 ) -> float | None:
-    """
-    Utility function to get the stamp of a Timestamp by semantics.
+    """Utility function to get the stamp of a Timestamp by semantics.
 
     Args:
         event: farm-ng protobuf event

--- a/py/farm_ng/core/stamp.py
+++ b/py/farm_ng/core/stamp.py
@@ -18,8 +18,9 @@ time_source = time
 class StampSemantics:
     """Recommended semantics for timestamp_pb2.Timestamp timestamps.
 
-    Example usage for when a device driver (service) receives a message from a device (e.g., a camera):     stamp =
-    get_monotonic_now(StampSemantics.DRIVER_RECEIVE)
+    Example usage for when a device driver (service) receives a message from a device (e.g., a camera):
+    Usage:
+        stamp = get_monotonic_now(StampSemantics.DRIVER_RECEIVE)
     """
 
     # When a gRPC client receives a message from a gRPC server.


### PR DESCRIPTION
Enforces the same docstring formatting in use for farm-ng-amiga

> `docformatter` automatically formats docstrings to follow a subset of the PEP 257 conventions. 
> https://github.com/PyCQA/docformatter/tree/master

Inspired by comment: https://github.com/farm-ng/farm-ng-core/pull/196#discussion_r1426577240