### PR TITLE
Add examples/cpp-vcpkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vcpkg"]
 	path = vcpkg
 	url = https://github.com/Microsoft/vcpkg.git
+[submodule "examples/cpp-vcpkg/vcpkg"]
+	path = examples/cpp-vcpkg/vcpkg
+	url = https://github.com/Microsoft/vcpkg.git

--- a/cmake/vcpkg/ports/farm-ng-core/portfile.cmake
+++ b/cmake/vcpkg/ports/farm-ng-core/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO farm-ng/farm-ng-core
+    REF "${VERSION}"
+    SHA512 0
+    HEAD_REF main
+)
+
+# TODO: Should be able to clean this up
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS}")
+set(VCPKG_CXX_FLAGS "-fconcepts ${VCPKG_CXX_FLAGS}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        "-DBUILD_SOPHUS_TESTS=Off" 
+        "-DFARM_NG_PROVIDER_DEV_PACKAGES=Sophus"
+        "-DCMAKE_CXX_STANDARD=17" # TODO: Should be able to remove
+        "-DCMAKE_CXX_EXTENSIONS=On" # TODO: Should be able to remove
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "farm_ng_core")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# TODO: Re-enable
+# configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/cmake/vcpkg/ports/farm-ng-core/vcpkg.json
+++ b/cmake/vcpkg/ports/farm-ng-core/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "farm-ng-core",
+  "version": "0.2.0",
+  "homepage": "https://github.com/farm-ng/farm-ng-core",
+  "description": "A foundational library for robotics and machine sensing applications.",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "boost-asio",
+    "cli11",
+    "eigen3",
+    "fmt",
+    {
+      "name": "grpc",
+      "features": ["codegen"]
+    },
+    "gtest",
+    "protobuf",
+    "tl-expected",
+    "boost-signals2"
+  ]
+}

--- a/examples/cpp-vcpkg/.gitignore
+++ b/examples/cpp-vcpkg/.gitignore
@@ -1,0 +1,2 @@
+overlay-ports
+out

--- a/examples/cpp-vcpkg/CMakeLists.txt
+++ b/examples/cpp-vcpkg/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(farm_ng_core_downstream VERSION 0.2.0)
+
+find_package(farm_ng_core REQUIRED)
+
+add_executable(HelloWorld helloworld.cpp)
+
+target_link_libraries(HelloWorld PRIVATE farm_ng::farm_ng_core_logging)

--- a/examples/cpp-vcpkg/CMakePresets.json
+++ b/examples/cpp-vcpkg/CMakePresets.json
@@ -1,0 +1,135 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 16,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "common",
+      "hidden": true,
+      "description": "Common farm-ng configuration",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-dynamic",
+        "CMAKE_CXX_FLAGS": "-Werror -Wall -Wextra -Wpedantic",
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_STANDARD_REQUIRED": "ON",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g",
+        "CMAKE_FIND_USE_PACKAGE_REGISTRY": "OFF"
+      },
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Linux", "Darwin"]
+      },
+      "warnings": {
+        "dev": false,
+        "deprecated": true,
+        "uninitialized": true,
+        "unusedCli": true,
+        "systemVars": false
+      },
+      "errors": {
+        "dev": false,
+        "deprecated": true
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "displayName": "GCC Debug",
+      "inherits": "common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "gcc-relwithdebinfo",
+      "displayName": "GCC RelWithDebInfo",
+      "inherits": "common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "clang-debug",
+      "displayName": "Clang Debug",
+      "inherits": "common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "clang-relwithdebinfo",
+      "displayName": "Clang RelWithDebInfo",
+      "inherits": "common",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc-debug"
+    },
+    {
+      "name": "gcc-relwithdebinfo",
+      "configurePreset": "gcc-relwithdebinfo"
+    },
+    {
+      "name": "clang-debug",
+      "configurePreset": "clang-debug"
+    },
+    {
+      "name": "clang-relwithdebinfo",
+      "configurePreset": "clang-relwithdebinfo"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test-common",
+      "description": "Test CMake settings that apply to all configurations",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    },
+    {
+      "name": "gcc-debug",
+      "inherits": "test-common",
+      "configurePreset": "gcc-debug"
+    },
+    {
+      "name": "gcc-relwithdebinfo",
+      "inherits": "test-common",
+      "configurePreset": "gcc-relwithdebinfo"
+    },
+    {
+      "name": "clang-debug",
+      "inherits": "test-common",
+      "configurePreset": "clang-debug"
+    },
+    {
+      "name": "clang-relwithdebinfo",
+      "inherits": "test-common",
+      "configurePreset": "clang-relwithdebinfo"
+    }
+  ]
+}

--- a/examples/cpp-vcpkg/README.md
+++ b/examples/cpp-vcpkg/README.md
@@ -1,0 +1,3 @@
+An example of a downstream project that consumes farm-ng-core with the [vcpkg](https://vcpkg.io/en/) package manager.
+
+See `build.sh` for build instructions.

--- a/examples/cpp-vcpkg/build.sh
+++ b/examples/cpp-vcpkg/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Execute commands from this script's directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+# Bootstrap vcpkg
+git submodule update --init --recursive
+./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+# Use latest farm-ng-core vcpkg ports as a local overlay
+# https://learn.microsoft.com/en-us/vcpkg/concepts/overlay-ports
+rsync -a --delete $DIR/../../cmake/vcpkg/ports/ ./overlay-ports/
+
+# In the overlay, use the current git sha as the farm-ng-core version
+portfile=$DIR/overlay-ports/farm-ng-core/portfile.cmake
+git_sha=`git rev-parse HEAD`
+git_sha512=`curl -sL https://github.com/farm-ng/farm-ng-core/archive/$git_sha.tar.gz | shasum -a 512 | head -c 128`
+sed -i "s/ REF.*$/ REF $git_sha # Auto-generated/" $portfile
+sed -i "s/ SHA512.*$/ SHA512 $git_sha512 # Auto-generated/" $portfile
+
+# Build
+cmake --preset clang-debug
+cmake --build --preset clang-debug
+
+# Run
+./out/build/clang-debug/HelloWorld

--- a/examples/cpp-vcpkg/helloworld.cpp
+++ b/examples/cpp-vcpkg/helloworld.cpp
@@ -1,0 +1,7 @@
+#include <farm_ng/core/logging/logger.h>
+
+int main()
+{
+    FARM_INFO("Hello, world");
+    return 0;
+}

--- a/examples/cpp-vcpkg/vcpkg-configuration.json
+++ b/examples/cpp-vcpkg/vcpkg-configuration.json
@@ -1,0 +1,15 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "6c937c32233bdf295ab2140dbce97fd00084a5f3",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ],
+  "overlay-ports": ["./overlay-ports"]
+}

--- a/examples/cpp-vcpkg/vcpkg.json
+++ b/examples/cpp-vcpkg/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": ["farm-ng-core"],
+  "overrides": [
+    {
+      "name": "fmt",
+      "version": "8.1.1"
+    }
+  ]
+}


### PR DESCRIPTION
Building on https://github.com/farm-ng/farm-ng-core/pull/202, adds an example project that consumes `farm-ng-core` via vcpkg. 

A build script is provided that can be invoked by CI for continuous testing of downstream vcpkg integration.