### PR TITLE
Update fmt version

### DIFF
--- a/cpp/farm_ng/core/enum/enum.h
+++ b/cpp/farm_ng/core/enum/enum.h
@@ -25,26 +25,30 @@
 
 #include "farm_ng/core/enum/enum_without_iostream.h"
 
+#include <fmt/ostream.h>
+
 #include <istream>
 #include <ostream>
 
 /// Adds ostream overloads for the enum.
-#define FARM_ENUM_IOSTREAM_OVERLOAD(EnumName)                     \
-  namespace enum_wrapper_ {                                       \
-  inline auto operator<<(std::ostream &os, EnumName##Impl value)  \
-      -> std::ostream & {                                         \
-    os << toPretty(value);                                        \
-    return os;                                                    \
-  }                                                               \
-  inline auto operator>>(std::istream &is, EnumName##Impl &value) \
-      -> std::istream & {                                         \
-    std::string str;                                              \
-    is >> str;                                                    \
-    if (!trySetFromString(value, str)) {                          \
-      throw std::runtime_error(std::string("Bad Value: ") + str); \
-    }                                                             \
-    return is;                                                    \
-  }                                                               \
+#define FARM_ENUM_IOSTREAM_OVERLOAD(EnumName)                                     \
+  namespace enum_wrapper_ {                                                       \
+  inline auto operator<<(std::ostream &os, EnumName##Impl value)                  \
+      -> std::ostream & {                                                         \
+    os << toPretty(value);                                                        \
+    return os;                                                                    \
+  }                                                                               \
+  inline auto operator>>(std::istream &is, EnumName##Impl &value)                 \
+      -> std::istream & {                                                         \
+    std::string str;                                                              \
+    is >> str;                                                                    \
+    if (!trySetFromString(value, str)) {                                          \
+      throw std::runtime_error(std::string("Bad Value: ") + str);                 \
+    }                                                                             \
+    return is;                                                                    \
+  }                                                                               \
+                                                                                  \
+  auto inline format_as(EnumName##Impl value) { return toPretty(value); }         \
   }  // namespace enum_wrapper_
 
 /// Convenience marco which defines the enum plus alias and adds the ostream

--- a/cpp/farm_ng/core/logging/CMakeLists.txt
+++ b/cpp/farm_ng/core/logging/CMakeLists.txt
@@ -13,6 +13,10 @@ farm_ng_add_library(farm_ng_core_logging
   HEADERS
     assert_within.h
     expected.h
+    fmt_ceres.h
+    fmt_eigen.h
+    fmt_grpc.h
+    fmt_ptr.h
     format.h
     trace_debug_log.h
     logger.h

--- a/cpp/farm_ng/core/logging/expected.h
+++ b/cpp/farm_ng/core/logging/expected.h
@@ -16,6 +16,7 @@
 
 #include "farm_ng/core/logging/logger.h"
 
+#include <fmt/ostream.h>
 #include <tl/expected.hpp>
 
 #include <iostream>
@@ -121,3 +122,7 @@ Expected<TT> fromOptional(std::optional<TT> optional) {
 }
 
 }  // namespace farm_ng
+
+template <typename T>
+    requires std::is_base_of_v<farm_ng::Error, T>
+struct fmt::formatter<T> : ostream_formatter {};

--- a/cpp/farm_ng/core/logging/fmt_ceres.h
+++ b/cpp/farm_ng/core/logging/fmt_ceres.h
@@ -1,0 +1,20 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <ceres/jet.h>
+#include <fmt/ostream.h>
+
+template <typename T, int N> struct fmt::formatter<ceres::Jet<T, N>> : ostream_formatter {};

--- a/cpp/farm_ng/core/logging/fmt_eigen.h
+++ b/cpp/farm_ng/core/logging/fmt_eigen.h
@@ -1,0 +1,25 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <Eigen/Dense>
+#include <fmt/ostream.h>
+
+template <typename T>
+    requires std::is_base_of_v<Eigen::DenseBase<T>, T>
+struct fmt::formatter<T> : ostream_formatter {};
+
+template <typename T, int N>
+struct fmt::formatter<Eigen::VectorBlock<T, N>> : ostream_formatter {};

--- a/cpp/farm_ng/core/logging/fmt_grpc.h
+++ b/cpp/farm_ng/core/logging/fmt_grpc.h
@@ -1,0 +1,20 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <fmt/ostream.h>
+#include <grpcpp/support/status_code_enum.h>
+
+template <> struct fmt::formatter<grpc::StatusCode> : ostream_formatter {};

--- a/cpp/farm_ng/core/logging/fmt_ptr.h
+++ b/cpp/farm_ng/core/logging/fmt_ptr.h
@@ -1,0 +1,27 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <fmt/ostream.h>
+
+#include <memory>
+
+template <typename T>
+struct fmt::formatter<std::shared_ptr<T>> {
+ constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+ auto format(const std::shared_ptr<T>& p, fmt::format_context& ctx) const {
+  return fmt::format_to(ctx.out(), "{}", fmt::ptr(p));
+ }
+};

--- a/cpp/farm_ng/core/logging/format.h
+++ b/cpp/farm_ng/core/logging/format.h
@@ -21,6 +21,7 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/std.h>
 
 #include <functional>
 #include <iostream>

--- a/cpp/farm_ng/core/misc/shared.h
+++ b/cpp/farm_ng/core/misc/shared.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "farm_ng/core/logging/expected.h"
+#include "farm_ng/core/logging/fmt_ptr.h"
 #include "farm_ng/core/misc/concept_utils.h"
 
 #include <memory>

--- a/cpp/farm_ng/core/misc/time_series_test.cpp
+++ b/cpp/farm_ng/core/misc/time_series_test.cpp
@@ -15,6 +15,7 @@
 #include "farm_ng/core/misc/time_series.h"
 
 #include "farm_ng/core/misc/conversions.h"
+#include "farm_ng/core/logging/fmt_eigen.h"
 #include "sophus/interp/interpolate.h"
 
 #include <gtest/gtest.h>

--- a/cpp/farm_ng/core/plotting/remote_plotting_client.cpp
+++ b/cpp/farm_ng/core/plotting/remote_plotting_client.cpp
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 #include "farm_ng/core/plotting/remote_plotting_client.h"
+#include "farm_ng/core/logging/fmt_grpc.h"
 
 #include "farm_ng/core/plotting/plotting.grpc.pb.h"
 #include "farm_ng/core/proto_conv/linalg/conv.h"

--- a/cpp/farm_ng/core/proto_conv/calculus/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/calculus/conv.cpp
@@ -14,6 +14,7 @@
 
 #include "farm_ng/core/proto_conv/calculus/conv.h"
 
+#include "farm_ng/core/logging/fmt_eigen.h"
 #include "farm_ng/core/proto_conv/linalg/conv.h"
 #include "farm_ng/core/proto_conv/std/conv_impl_macro.ipp"
 

--- a/cpp/farm_ng/core/proto_conv/image/conv_test.cpp
+++ b/cpp/farm_ng/core/proto_conv/image/conv_test.cpp
@@ -14,6 +14,8 @@
 
 #include "farm_ng/core/proto_conv/image/conv.h"
 
+#include "farm_ng/core/logging/fmt_eigen.h"
+
 #include <gtest/gtest.h>
 
 namespace farm_ng::test {

--- a/cpp/sophus/common/common.h
+++ b/cpp/sophus/common/common.h
@@ -15,6 +15,7 @@
 #include <Eigen/Geometry>
 #include <farm_ng/core/logging/assert_within.h>
 #include <farm_ng/core/logging/expected.h>
+#include <farm_ng/core/logging/fmt_eigen.h>
 #include <farm_ng/core/logging/format.h>
 #include <farm_ng/core/logging/logger.h>
 #include <farm_ng/core/misc/variant_utils.h>

--- a/cpp/sophus/image/image_size.h
+++ b/cpp/sophus/image/image_size.h
@@ -12,6 +12,7 @@
 #include "sophus/common/common.h"
 
 #include <Eigen/Dense>
+#include <fmt/ostream.h>
 
 #include <iostream>
 
@@ -84,3 +85,5 @@ auto operator<(ImageSize const& lhs, ImageSize const& rhs) -> bool;
 auto operator<<(std::ostream& os, ImageSize const& image_size) -> std::ostream&;
 
 }  // namespace sophus
+
+template <> struct fmt::formatter<sophus::ImageSize> : ostream_formatter {};

--- a/cpp/sophus/image/layout.h
+++ b/cpp/sophus/image/layout.h
@@ -13,6 +13,7 @@
 #include "sophus/image/image_size.h"
 
 #include <Eigen/Dense>
+#include <fmt/ostream.h>
 
 #include <iostream>
 
@@ -81,3 +82,5 @@ auto operator!=(ImageLayout const& lhs, ImageLayout const& rhs) -> bool;
 auto operator<<(std::ostream& os, ImageLayout const& layout) -> std::ostream&;
 
 }  // namespace sophus
+
+template <> struct fmt::formatter<sophus::ImageLayout> : ostream_formatter {};

--- a/cpp/sophus/image/pixel_format.h
+++ b/cpp/sophus/image/pixel_format.h
@@ -10,6 +10,8 @@
 
 #include "sophus/image/image_types.h"
 
+#include <fmt/ostream.h>
+
 namespace sophus {
 
 struct PixelFormat {
@@ -47,3 +49,5 @@ auto operator==(PixelFormat const& lhs, PixelFormat const& rhs) -> bool;
 /// "4U8";
 auto operator<<(std::ostream& os, PixelFormat const& type) -> std::ostream&;
 }  // namespace sophus
+
+template <> struct fmt::formatter<sophus::PixelFormat> : ostream_formatter {};

--- a/cpp/sophus/lie/impl/rotation2.h
+++ b/cpp/sophus/lie/impl/rotation2.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "farm_ng/core/logging/fmt_ceres.h"
 #include "sophus/concepts/lie_group.h"
 #include "sophus/manifold/complex.h"
 #include "sophus/manifold/unit_vector.h"

--- a/examples/cpp-vcpkg/vcpkg.json
+++ b/examples/cpp-vcpkg/vcpkg.json
@@ -1,9 +1,3 @@
 {
-  "dependencies": ["farm-ng-core"],
-  "overrides": [
-    {
-      "name": "fmt",
-      "version": "8.1.1"
-    }
-  ]
+  "dependencies": ["farm-ng-core"]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,10 +4,7 @@
     "ceres",
     "cli11",
     "eigen3",
-    {
-      "name": "fmt",
-      "version>=": "8.1.1"
-    },
+    "fmt",
     {
       "name": "grpc",
       "features": ["codegen"]
@@ -16,11 +13,5 @@
     "protobuf",
     "tl-expected",
     "boost-signals2"
-  ],
-  "overrides": [
-    {
-      "name": "fmt",
-      "version": "8.1.1"
-    }
   ]
 }


### PR DESCRIPTION
Building on https://github.com/farm-ng/farm-ng-core/pull/202, updates `fmt` to latest version so we do not have to pin to 8.1.

There were some changes between fmt 8.1 and 10.1 around support for `std::ostream` formatting -- it is now required to [explicitly specialize a template](https://fmt.dev/latest/api.html#std-ostream-support) to register an ostream formatter. This prevents [possible ODR violation](https://github.com/fmtlib/fmt/issues/2357).

AFAIK the C++20-standardized std::format doesn't support ostream formatting at all. Long-term we may want to consider an approach that falls back to `fmt` only when standard library support is not present -- this would require moving away from relying on ostream formatting altogether.