### PR TITLE
Feat message optional proto

### DIFF
--- a/cpp/farm_ng/core/proto_conv/calculus/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/calculus/conv.cpp
@@ -16,7 +16,7 @@
 
 #include "farm_ng/core/logging/fmt_eigen.h"
 #include "farm_ng/core/proto_conv/linalg/conv.h"
-#include "farm_ng/core/proto_conv/std/conv_impl_macro.ipp"
+#include "farm_ng/core/proto_conv/std/repeated_message_impl_macro.ipp"
 
 namespace farm_ng {
 
@@ -132,6 +132,7 @@ auto toProt<sophus::Region2F64>(sophus::Region2F64 const& region)
   return proto;
 }
 
-FARM_CONV_IMPL_REPEATED(core::proto::RepeatedG0Region2F64, sophus::Region2F64)
+FARM_CONV_IMPL_REPEATED_MESSAGE(
+    core::proto::RepeatedG0Region2F64, std::deque<sophus::Region2F64>)
 
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/lie/CMakeLists.txt
+++ b/cpp/farm_ng/core/proto_conv/lie/CMakeLists.txt
@@ -10,6 +10,7 @@ farm_ng_add_library(farm_ng_core_proto_conv_lie
 target_link_libraries(farm_ng_core_proto_conv_lie PUBLIC
   farm_ng_core::sophus_lie
   protobuf::libprotobuf
+  farm_ng_core::farm_ng_core_proto_conv_std
   farm_ng_core::farm_ng_core_proto_conv_linalg
   farm_ng_core::farm_ng_core_prototools
 )

--- a/cpp/farm_ng/core/proto_conv/lie/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/lie/conv.cpp
@@ -15,6 +15,8 @@
 #include "farm_ng/core/proto_conv/lie/conv.h"
 
 #include "farm_ng/core/proto_conv/linalg/conv.h"
+#include "farm_ng/core/proto_conv/std/optional_message_impl_macro.ipp"
+#include "farm_ng/core/proto_conv/std/repeated_message_impl_macro.ipp"
 
 namespace farm_ng {
 
@@ -105,5 +107,11 @@ auto toProt<sophus::Isometry3F64>(sophus::Isometry3F64 const& pose)
   *proto.mutable_translation() = toProt(pose.translation().eval());
   return proto;
 }
+
+FARM_CONV_IMPL_MESSAGE_OPTIONAL(
+    core::proto::OptionalG0Isometry3F64, sophus::Isometry3F64);
+
+FARM_CONV_IMPL_REPEATED_MESSAGE(
+    core::proto::RepeatedG0Isometry3F64, std::vector<sophus::Isometry3F64>);
 
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/lie/conv.h
+++ b/cpp/farm_ng/core/proto_conv/lie/conv.h
@@ -15,11 +15,14 @@
 #pragma once
 
 #include "farm_ng/core/lie.pb.h"
+#include "farm_ng/core/proto_conv/std/conv.h"
 #include "farm_ng/core/proto_conv/traits.h"
 #include "sophus/lie/isometry2.h"
 #include "sophus/lie/isometry3.h"
 #include "sophus/lie/rotation2.h"
 #include "sophus/lie/rotation3.h"
+
+#include <vector>
 
 namespace farm_ng {
 
@@ -28,5 +31,10 @@ FARM_PROTO_CONV_TRAIT(sophus::Rotation2F64, core::proto::Rotation2F64);
 FARM_PROTO_CONV_TRAIT(sophus::Isometry2F64, core::proto::Isometry2F64);
 FARM_PROTO_CONV_TRAIT(sophus::Rotation3F64, core::proto::Rotation3F64);
 FARM_PROTO_CONV_TRAIT(sophus::Isometry3F64, core::proto::Isometry3F64);
+
+FARM_PROTO_CONV_TRAIT(
+    std::optional<sophus::Isometry3F64>, core::proto::OptionalG0Isometry3F64);
+FARM_PROTO_CONV_TRAIT(
+    std::vector<sophus::Isometry3F64>, core::proto::RepeatedG0Isometry3F64);
 
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/plotting/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/plotting/conv.cpp
@@ -19,7 +19,7 @@
 #include "farm_ng/core/proto_conv/color/conv.h"
 #include "farm_ng/core/proto_conv/linalg/conv.h"
 #include "farm_ng/core/proto_conv/std/conv.h"
-#include "farm_ng/core/proto_conv/std/conv_impl_macro.ipp"
+#include "farm_ng/core/proto_conv/std/repeated_message_impl_macro.ipp"
 #include "farm_ng/core/proto_conv/struct/conv_impl_macro.ipp"
 
 namespace farm_ng {
@@ -124,8 +124,9 @@ auto toProt<std::deque<plotting::Vec7d>>(std::deque<plotting::Vec7d> const& v)
 FARM_PROTO_CONV_IMPL(
     plotting::ColoredRect, core::plotting::proto::ColoredRect, (color, region));
 
-FARM_CONV_IMPL_REPEATED(
-    core::plotting::proto::RepeatedG0ColoredRect, plotting::ColoredRect);
+FARM_CONV_IMPL_REPEATED_MESSAGE(
+    core::plotting::proto::RepeatedG0ColoredRect,
+    std::deque<plotting::ColoredRect>);
 
 FARM_PROTO_CONV_IMPL(
     plotting::RectPlot,

--- a/cpp/farm_ng/core/proto_conv/std/conv.cpp
+++ b/cpp/farm_ng/core/proto_conv/std/conv.cpp
@@ -13,19 +13,21 @@
 //    limitations under the License.
 #include "farm_ng/core/proto_conv/std/conv.h"
 
-#include "farm_ng/core/proto_conv/std/conv_impl_macro.ipp"
+#include "farm_ng/core/proto_conv/lie/conv.h"
+#include "farm_ng/core/proto_conv/std/optional_primitive_impl_macro.ipp"
+#include "farm_ng/core/proto_conv/std/repeated_primitive_impl_macro.ipp"
 
 namespace farm_ng {
 
-FARM_PP_SEQ_FOR_EACH(
-    FARM_CONV_IMPL_OPTIONAL_ONE_ITER,
-    _,
-    ((core::proto::OptionalG0Float, float))         //
-    ((core::proto::OptionalG0Double, double))       //
-    ((core::proto::OptionalG0Int32, int32_t))       //
-    ((core::proto::OptionalG0Int64, int64_t))       //
-    ((core::proto::OptionalG0String, std::string))  //
-    ((core::proto::OptionalG0Bool, bool)));
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0Float, float);
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0Double, double);
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0Int32, int32_t);
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0Int64, int64_t);
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0String, std::string);
+FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(core::proto::OptionalG0Bool, bool);
+
+FARM_CONV_IMPL_REPEATED_PRIMITIVE(
+    core::proto::RepeatedG0Float, std::vector<float>);
 
 template <>
 auto fromProt<core::proto::FileSystemPath>(

--- a/cpp/farm_ng/core/proto_conv/std/conv.h
+++ b/cpp/farm_ng/core/proto_conv/std/conv.h
@@ -22,6 +22,7 @@
 
 namespace farm_ng {
 
+// optional of primitive types
 FARM_PROTO_CONV_TRAIT(std::optional<float>, core::proto::OptionalG0Float);
 FARM_PROTO_CONV_TRAIT(std::optional<double>, core::proto::OptionalG0Double);
 FARM_PROTO_CONV_TRAIT(std::optional<int32_t>, core::proto::OptionalG0Int32);
@@ -29,6 +30,9 @@ FARM_PROTO_CONV_TRAIT(std::optional<int64_t>, core::proto::OptionalG0Int64);
 FARM_PROTO_CONV_TRAIT(
     std::optional<std::string>, core::proto::OptionalG0String);
 FARM_PROTO_CONV_TRAIT(std::optional<bool>, core::proto::OptionalG0Bool);
+
+// std::vector of primitive types
+FARM_PROTO_CONV_TRAIT(std::vector<float>, core::proto::RepeatedG0Float);
 
 FARM_PROTO_CONV_TRAIT(std::filesystem::path, core::proto::FileSystemPath);
 

--- a/cpp/farm_ng/core/proto_conv/std/optional_message_impl_macro.ipp
+++ b/cpp/farm_ng/core/proto_conv/std/optional_message_impl_macro.ipp
@@ -25,13 +25,14 @@
 
 namespace farm_ng {
 
-#define FARM_CONV_IMPL_OPTIONAL(Proto_Type_, Cpp_Type_)                    \
+#define FARM_CONV_IMPL_MESSAGE_OPTIONAL(Proto_Type_, Cpp_Type_)            \
   template <>                                                              \
   auto fromProt<Proto_Type_>(Proto_Type_ const& proto)                     \
       -> Expected<std::optional<Cpp_Type_>> {                              \
     std::optional<Cpp_Type_> v;                                            \
-    if (proto.has_value()) {                                               \
-      v = proto.value();                                                   \
+    if (proto.has_message()) {                                             \
+      FARM_TRY(auto, vv, fromProt(proto.value()));                         \
+      v = vv;                                                              \
     } else {                                                               \
       v = std::nullopt;                                                    \
     }                                                                      \
@@ -43,41 +44,12 @@ namespace farm_ng {
       -> Proto_Type_ {                                                     \
     Proto_Type_ proto;                                                     \
     if (v.has_value()) {                                                   \
-      proto.set_value(v.value());                                          \
-      proto.set_has_value(true);                                           \
+      *proto.mutable_value() = toProt(v.value());                          \
+      proto.set_has_message(true);                                         \
     } else {                                                               \
-      proto.set_has_value(false);                                          \
+      proto.set_has_message(false);                                        \
     }                                                                      \
     return proto;                                                          \
-  }
-
-// Proxy for FARM_CONV_IMPL_OPTIONAL to make it callable from
-// FARM_PP_SEQ_FOR_EACH.
-#define FARM_CONV_IMPL_OPTIONAL_ONE_ITER(D0_, D1_, Proto_Cpp_Pair_) \
-  FARM_CONV_IMPL_OPTIONAL(                                          \
-      FARM_PP_TUPLE_ELEM(0, Proto_Cpp_Pair_),                       \
-      FARM_PP_TUPLE_ELEM(1, Proto_Cpp_Pair_))
-
-#define FARM_CONV_IMPL_REPEATED(Proto_Type_, Cpp_Type_)              \
-  template <>                                                        \
-  auto fromProt<Proto_Type_>(Proto_Type_ const& proto)               \
-      -> Expected<std::deque<Cpp_Type_>> {                           \
-    std::deque<Cpp_Type_> v;                                         \
-    for (int i = 0; i < proto.value_size(); ++i) {                   \
-      FARM_TRY(auto, value, fromProt(proto.value(i)));               \
-      v.push_back(value);                                            \
-    }                                                                \
-    return v;                                                        \
-  }                                                                  \
-                                                                     \
-  template <>                                                        \
-  auto toProt<std::deque<Cpp_Type_>>(std::deque<Cpp_Type_> const& v) \
-      -> Proto_Type_ {                                               \
-    Proto_Type_ proto;                                               \
-    for (auto const& value : v) {                                    \
-      *proto.add_value() = toProt(value);                            \
-    }                                                                \
-    return proto;                                                    \
   }
 
 }  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/std/optional_primitive_impl_macro.ipp
+++ b/cpp/farm_ng/core/proto_conv/std/optional_primitive_impl_macro.ipp
@@ -1,0 +1,54 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+// NOTE: This file should typically only be included in *.cpp files - to keep
+// compile times low.
+
+#include "farm_ng/core/proto_conv/std/conv.h"
+
+#include <farm_pp/preprocessor/tuple/elem.hpp>
+
+#include <optional>
+
+namespace farm_ng {
+
+#define FARM_CONV_IMPL_PRIMITIVE_OPTIONAL(Proto_Type_, Cpp_Type_)          \
+  template <>                                                              \
+  auto fromProt<Proto_Type_>(Proto_Type_ const& proto)                     \
+      -> Expected<std::optional<Cpp_Type_>> {                              \
+    std::optional<Cpp_Type_> v;                                            \
+    if (proto.has_value()) {                                               \
+      v = proto.value();                                                   \
+    } else {                                                               \
+      v = std::nullopt;                                                    \
+    }                                                                      \
+    return v;                                                              \
+  }                                                                        \
+                                                                           \
+  template <>                                                              \
+  auto toProt<std::optional<Cpp_Type_>>(std::optional<Cpp_Type_> const& v) \
+      -> Proto_Type_ {                                                     \
+    Proto_Type_ proto;                                                     \
+    if (v.has_value()) {                                                   \
+      proto.set_value(v.value());                                          \
+      proto.set_has_value(true);                                           \
+    } else {                                                               \
+      proto.set_has_value(false);                                          \
+    }                                                                      \
+    return proto;                                                          \
+  }
+
+}  // namespace farm_ng

--- a/cpp/farm_ng/core/proto_conv/std/repeated_message_impl_macro.ipp
+++ b/cpp/farm_ng/core/proto_conv/std/repeated_message_impl_macro.ipp
@@ -1,0 +1,35 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#define FARM_CONV_IMPL_REPEATED_MESSAGE(Proto_Type_, Cpp_Type_Container_) \
+  template <>                                                             \
+  auto fromProt<Proto_Type_>(Proto_Type_ const& proto)                    \
+      -> Expected<Cpp_Type_Container_> {                                  \
+    Cpp_Type_Container_ v;                                                \
+    for (int i = 0; i < proto.value_size(); ++i) {                        \
+      FARM_TRY(auto, value, fromProt(proto.value(i)));                    \
+      v.push_back(value);                                                 \
+    }                                                                     \
+    return v;                                                             \
+  }                                                                       \
+                                                                          \
+  template <>                                                             \
+  auto toProt<Cpp_Type_Container_>(Cpp_Type_Container_ const& v)          \
+      -> Proto_Type_ {                                                    \
+    Proto_Type_ proto;                                                    \
+    for (auto const& value : v) {                                         \
+      *proto.add_value() = toProt(value);                                 \
+    }                                                                     \
+    return proto;                                                         \
+  }

--- a/cpp/farm_ng/core/proto_conv/std/repeated_primitive_impl_macro.ipp
+++ b/cpp/farm_ng/core/proto_conv/std/repeated_primitive_impl_macro.ipp
@@ -1,0 +1,34 @@
+//    Copyright 2022, farm-ng inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#define FARM_CONV_IMPL_REPEATED_PRIMITIVE(Proto_Type_, Cpp_Type_Container_) \
+  template <>                                                               \
+  auto fromProt<Proto_Type_>(Proto_Type_ const& proto)                      \
+      -> Expected<Cpp_Type_Container_> {                                    \
+    Cpp_Type_Container_ v;                                                  \
+    for (int i = 0; i < proto.value_size(); ++i) {                          \
+      v.push_back(proto.value(i));                                          \
+    }                                                                       \
+    return v;                                                               \
+  }                                                                         \
+                                                                            \
+  template <>                                                               \
+  auto toProt<Cpp_Type_Container_>(Cpp_Type_Container_ const& v)            \
+      -> Proto_Type_ {                                                      \
+    Proto_Type_ proto;                                                      \
+    for (auto const& value : v) {                                           \
+      proto.add_value(value);                                               \
+    }                                                                       \
+    return proto;                                                           \
+  }

--- a/protos/farm_ng/core/lie.proto
+++ b/protos/farm_ng/core/lie.proto
@@ -15,6 +15,7 @@
 syntax = "proto3";
 
 import "farm_ng/core/linalg.proto";
+import "farm_ng/core/std.proto";
 
 package farm_ng.core.proto;
 
@@ -30,6 +31,15 @@ message Rotation2F64 {
 message Isometry2F64 {
   Rotation2F64 rotation = 1;
   Vec2F64 translation = 2;
+}
+
+message OptionalG0Isometry3F64 {
+  Isometry3F64 value = 1;
+  bool has_message = 2;
+}
+
+message RepeatedG0Isometry3F64 {
+  repeated Isometry3F64 value = 1;
 }
 
 message Rotation3F64 {

--- a/protos/farm_ng/core/std.proto
+++ b/protos/farm_ng/core/std.proto
@@ -22,6 +22,23 @@ package farm_ng.core.proto;
 // MesageNameG0ParameterName - e.g. OptionalG0Double which is
 // std::optional<double> in c++
 
+// Field naming pattern for primitives:
+//
+// ```
+// PRIMITIVE value = 1;
+// bool has_value = 2;
+// ````
+
+// Field naming pattern for messages:
+//
+// ```
+// MESSAGE value = 1;
+// bool has_message = 2;
+// ```
+//
+// ("has_value" is already auto-generaged for "value" in cpp
+//  proto, so we can't use that field name.)
+
 message OptionalG0Float {
   float value = 1;
   bool has_value = 2;
@@ -52,5 +69,8 @@ message OptionalG0String {
   bool has_value = 2;
 }
 
+message RepeatedG0Float {
+  repeated float value = 1;
+}
 
 message FileSystemPath { string path_string = 1; }

--- a/protos/farm_ng/core/std.proto
+++ b/protos/farm_ng/core/std.proto
@@ -36,7 +36,7 @@ package farm_ng.core.proto;
 // bool has_message = 2;
 // ```
 //
-// ("has_value" is already auto-generaged for "value" in cpp
+// ("has_value" is already auto-generated for "value" in cpp
 //  proto, so we can't use that field name.)
 
 message OptionalG0Float {


### PR DESCRIPTION
Adding / refining the following four macros:

``FARM_CONV_IMPL_PRIMITIVE_OPTIONAL`` -  to/from proto conversion for std::optional of primitive types
``FARM_CONV_IMPL_MESSAGE_OPTIONAL`` - for non-primitive types
``FARM_CONV_IMPL_REPEATED_PRIMITIVE`` - to/from proto conversion for std::vector/std::deque of primitive types
``FARM_CONV_IMPL_REPEATED_MESSAGE`` - for non-primitive types

This PR also deletes the ``FARM_CONV_IMPL_OPTIONAL_ONE_ITER`` which did not add much value, but hampered code readability. 

Note:

The proto <-> c++ association is still to be 1:1, so one need to decided whether FARM_CONV_IMPL_REPEATED_MESSAGE shall target a std::vector or a std::deque.

TODO (future work):
Explore many to 1 proto <-> c++ conversion associations. This likely requires changes to the fromProt function templates (and underlying traits).