### PR TITLE
Add filename option to log formatting

### DIFF
--- a/cpp/farm_ng/core/logging/logger.cpp
+++ b/cpp/farm_ng/core/logging/logger.cpp
@@ -42,6 +42,9 @@ void StreamLogger::writeHeader(
     std::string const& file,
     int line,
     std::string const& function) {
+  auto filename_idx = file.rfind("/", std::string::npos);
+  auto parent_idx = file.rfind("/", filename_idx - 1);
+
   write(
       disk_logging_,
       FARM_FORMAT(
@@ -51,6 +54,8 @@ void StreamLogger::writeHeader(
           fmt::arg("text", header_text),
           fmt::arg("file", file),
           fmt::arg("line", line),
+          fmt::arg("fileparent", file.substr(parent_idx + 1)),
+          fmt::arg("filename", file.substr(filename_idx + 1)),
           fmt::arg("function", function)));
 }
 
@@ -115,7 +120,7 @@ void StreamLogger::flush(DiskLogging& disk_logging) {
 }
 
 std::string const StreamLogger::kDefaultHeaderFormat =
-    "[FARM {text} in {file}:{line}]\n";
+    "[FARM {text} in {fileparent}:{line}]\n";
 
 StreamLogger::LogClock const StreamLogger::kDefaultLogClock =
     StreamLogger::LogClock{.now = []() {

--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -306,7 +306,7 @@ inline StreamLogger& defaultLogger() {
     }                                                           \
     if (counter == 1) {                                         \
       farm_ng::defaultLogger().log(                             \
-          farm_ng::LogLevel::warning,                              \
+          farm_ng::LogLevel::warning,                           \
           FARM_FORMAT("LOG WARN EVERY N( = {} )", #N),          \
           __FILE__,                                             \
           __LINE__,                                             \


### PR DESCRIPTION
The file option we use by default right now is very long and usually includes local paths on the host the software was built on. This modification provides a filename option to shorten the length of the prefix for the output while still retaining the ability to find where the log was coming from.

The default is updated to use the filename option as well.