### PR TITLE
feat: batch/SIMD processiong feature for eigen/sophus2

### DIFF
--- a/cpp/farm_ng/core/logging/assert_within.h
+++ b/cpp/farm_ng/core/logging/assert_within.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "farm_ng/core/logging/expected.h"
+#include "sophus2/linalg/batch.h"
 
 #include <Eigen/Core>
 
@@ -124,14 +125,12 @@ struct CheckNear<
       return Success{};
     }
     return FARM_UNEXPECTED(
-        "Not true: {}[{}, {}] near {}[{}, {}]; has error of {} (thr: {})\n"
+        "Not true: {} near {} [r:{},c:{}]; has error of {} (thr: {})\n"
         "LHS `{}` is:\n"
         "{}\n\n"
         "RHS `{}` is:\n"
         "{}\n\n",
         lhs_cstr,
-        max_row_idx,
-        max_col_idx,
         rhs_cstr,
         max_row_idx,
         max_col_idx,
@@ -141,6 +140,72 @@ struct CheckNear<
         lhs,
         rhs_cstr,
         rhs);
+  }
+};
+
+template <class TBatch, int kRows, int kCols>
+struct CheckNear<
+    Eigen::Matrix<TBatch, kRows, kCols>,
+    Eigen::Matrix<TBatch, kRows, kCols>,
+    std::enable_if_t<sophus2::BatchTrait<TBatch>::kIsBatch>> {
+  static Expected<Success> check(
+      bool check_relative,
+      Eigen::Matrix<TBatch, kRows, kCols> const& lhs,
+      char const* lhs_cstr,
+      Eigen::Matrix<TBatch, kRows, kCols> const& rhs,
+      char const* rhs_cstr,
+      double const& thr) {
+    double max_error = 0.0;
+    int max_row_idx = -1;
+    int max_col_idx = -1;
+    int max_batch_idx = -1;
+
+    auto nearness_fn =
+        check_relative
+            ? [](double x, double y) { return relativeCloseness(x, y); }
+            : [](double x, double y) { return std::abs(x - y); };
+
+    for (int c = 0; c < lhs.cols(); ++c) {
+      for (int r = 0; r < lhs.rows(); ++r) {
+        for (int batch = 0; batch < sophus2::BatchTrait<TBatch>::kBatchSize;
+             ++batch) {
+          double err =
+              nearness_fn(lhs(r, c).lanes[batch], rhs(r, c).lanes[batch]);
+
+          if (!(err <= max_error)) {
+            // inverted comparison,  so we also end up here if err or max_error
+            // are NAN
+            max_error = err;
+            max_row_idx = r;
+            max_col_idx = c;
+            max_batch_idx = batch;
+          }
+        }
+      }
+    }
+    if (max_error < thr) {
+      // all errors below threshold
+      return Success{};
+    }
+    return FARM_UNEXPECTED(
+        "Not true: {} near {} [r:{}c:{}b:{}]; has error of {} (thr: {})\n"
+        "LHS `{}` is:\n"
+        "{}\n\n"
+        "RHS `{}` is:\n"
+        "{}\n\n",
+        lhs_cstr,
+        rhs_cstr,
+        max_row_idx,
+        max_col_idx,
+        max_batch_idx,
+        max_error,
+        thr,
+        lhs_cstr,
+        lhs,
+        rhs_cstr,
+        rhs);
+
+    return Success{};
   }
 };
 
@@ -164,8 +229,8 @@ inline Expected<Success> checkRelativeNear(
     double thr) {
   if (!((thr >= 0.0) && (thr <= 1.0))) {
     FARM_WARN(
-        "The threshold of the WITHIN_REL macro shall be in [0.0, 1.0], but we "
-        "got `{}`.",
+        "The threshold of the WITHIN_REL macro shall be in [0.0, 1.0], but "
+        "we got `{}`.",
         thr);
   }
   return CheckNear<TScalar, TScalar2>::check(

--- a/cpp/sophus2/concepts/division_ring_prop_tests.h
+++ b/cpp/sophus2/concepts/division_ring_prop_tests.h
@@ -42,7 +42,7 @@ struct DivisionRingTestSuite {
           SOPHUS_ASSERT_WITHIN_REL(
               left_hugging.params(),
               right_hugging.params(),
-              10.0 * kEpsilonSqrt<Scalar>,
+              10.0 * kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>,
               "`(g1*g2)*g3 == g1*(g2*g3)` Test for {}, #{}/#{}/#{}",
               ring_name,
               params_id,
@@ -70,7 +70,7 @@ struct DivisionRingTestSuite {
           SOPHUS_ASSERT_WITHIN_REL(
               left_hugging.params(),
               right_hugging.params(),
-              kEpsilonSqrt<Scalar>,
+              kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>,
               "`g1 * g2 == g2 * g3` Test for {}, #{}/#{}",
               ring_name,
               params_id,
@@ -90,16 +90,31 @@ struct DivisionRingTestSuite {
           Ring g2 = Ring::fromParams(params2);
           Ring left_hugging = g1 * g2;
           Ring right_hugging = g2 * g1;
-          ++num_cases;
-          if ((left_hugging.params() - right_hugging.params()).norm() <
-              kEpsilonSqrt<Scalar>) {
-            ++num_commutativity;
+
+          if constexpr (BatchTrait<Scalar>::kIsBatch) {
+            Scalar batch_nrm =
+                (left_hugging.params() - right_hugging.params()).norm();
+
+            for (int b = 0; b < BatchTrait<Scalar>::kBatchSize; ++b) {
+              if (batch_nrm.lanes[b] <
+                  kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>) {
+                ++num_commutativity;
+              }
+            }
+
+          } else {
+            ++num_cases;
+
+            if ((left_hugging.params() - right_hugging.params()).norm() <
+                kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>) {
+              ++num_commutativity;
+            }
           }
         }
       }
       if (num_cases > 0) {
-        Scalar commutativity_percentage =
-            Scalar(num_commutativity) / Scalar(num_cases);
+        double commutativity_percentage =
+            double(num_commutativity) / double(num_cases);
         SOPHUS_ASSERT_LE(commutativity_percentage, 0.75);
       }
     }
@@ -114,7 +129,7 @@ struct DivisionRingTestSuite {
       SOPHUS_ASSERT_WITHIN_REL(
           g.params(),
           (g + Ring::zero()).params(),
-          kEpsilonSqrt<Scalar>,
+          kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>,
           "`g + 0 == g` Test for {}, #{}",
           ring_name,
           params_id);
@@ -127,14 +142,15 @@ struct DivisionRingTestSuite {
       Params params = SOPHUS_AT(kParamsExamples, params_id);
       Ring g = Ring::fromParams(params);
 
-      if (g.params().norm() < kEpsilonSqrt<Scalar>) {
+      if (BatchTrait<Scalar>::anyLessEqual(
+              g.params().norm(), kEpsilonSqrt<Scalar>)) {
         continue;
       }
 
       SOPHUS_ASSERT_WITHIN_REL(
           g.params(),
           (g * Ring::one()).params(),
-          kEpsilonSqrt<Scalar>,
+          kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>,
           "`g * 1 == g` Test for {}, #{}",
           ring_name,
           params_id);
@@ -142,7 +158,7 @@ struct DivisionRingTestSuite {
       SOPHUS_ASSERT_WITHIN_REL(
           (g * g.inverse()).params(),
           Ring::one().params(),
-          kEpsilonSqrt<Scalar>,
+          kEpsilonSqrt<typename BatchTrait<Scalar>::Scalar>,
           "`g * 1 == g` Test for {}, #{}",
           ring_name,
           params_id);

--- a/cpp/sophus2/lie/impl/rotation2.h
+++ b/cpp/sophus2/lie/impl/rotation2.h
@@ -204,6 +204,8 @@ class Rotation2Impl {
     Scalar halftheta_by_tan_of_halftheta;
 
     Scalar real_minus_one = z.x() - Scalar(1.);
+    using std::abs;
+
     if (abs(real_minus_one) < kEpsilon<Scalar>) {
       halftheta_by_tan_of_halftheta =
           Scalar(1.) - Scalar(1. / 12) * theta[0] * theta[0];

--- a/cpp/sophus2/linalg/CMakeLists.txt
+++ b/cpp/sophus2/linalg/CMakeLists.txt
@@ -6,6 +6,7 @@ sophus2_linalg
 ]]
 
 set(sophus2_linalg_src_prefixes
+    batch
     cast
     homogeneous
     orthogonal

--- a/cpp/sophus2/linalg/batch.h
+++ b/cpp/sophus2/linalg/batch.h
@@ -1,0 +1,180 @@
+// Copyright (c) 2011, Hauke Strasdat
+// Copyright (c) 2012, Steven Lovegrove
+// Copyright (c) 2021, farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include "sophus2/common/common.h"
+
+namespace sophus2 {
+
+// Following similar pattern as ceres::Jet
+template <class TT, int kNum>
+struct Batch {
+  Batch() {}
+
+  explicit Batch(Eigen::Array<TT, kNum, 1> const& b_) : lanes(b_) {}
+
+  // Constructor from scalar: a + 0.
+  explicit Batch(const TT& value) { lanes.setConstant(TT(value)); }
+
+  // Compound operators
+  Batch<TT, kNum>& operator+=(Batch<TT, kNum> const& y) {
+    *this = *this + y;
+    return *this;
+  }
+
+  Batch<TT, kNum> operator-() const { return Batch<TT, kNum>(-this->lanes); }
+
+  bool operator==(Batch<TT, kNum> const& y) {
+    return (this->lanes == y.lanes).all();
+  }
+
+  Eigen::Array<TT, kNum, 1> lanes;
+};
+
+template <class TT, int kNum>
+auto operator<<(std::ostream& os, Batch<TT, kNum> const& batch)
+    -> std::ostream& {
+  os << "[" << batch.lanes << "]";
+  return os;
+}
+
+template <class T, int N>
+inline Batch<T, N> hypot(Batch<T, N> const& f, Batch<T, N> const& g) {
+  return Batch{((f.lanes * f.lanes) + (g.lanes * g.lanes)).sqrt().eval()};
+}
+
+template <class T, int N>
+inline Batch<T, N> abs(Batch<T, N> const& f) {
+  return Batch{f.lanes.abs().eval()};
+}
+
+template <class T, int N>
+inline Batch<T, N> sqrt(Batch<T, N> const& f) {
+  return Batch{f.lanes.sqrt().eval()};
+}
+
+template <class T, int N>
+inline Batch<T, N> operator-(Batch<T, N> const& f, Batch<T, N> const& g) {
+  return Batch{(f.lanes - g.lanes).eval()};
+}
+
+template <class T, int N>
+inline Batch<T, N> operator+(Batch<T, N> const& f, Batch<T, N> const& g) {
+  return Batch{(f.lanes + g.lanes).eval()};
+}
+template <class T, int N>
+inline Batch<T, N> operator*(Batch<T, N> const& f, Batch<T, N> const& g) {
+  return Batch{(f.lanes * g.lanes).eval()};
+}
+
+template <class T, int N>
+inline Batch<T, N> operator/(Batch<T, N> const& f, Batch<T, N> const& g) {
+  return Batch{(f.lanes / g.lanes).eval()};
+}
+
+template <class TT, int N>
+inline Batch<TT, N> operator*(Batch<TT, N> const& f, TT s) {
+  return Batch{(f.lanes * s).eval()};
+}
+
+template <class TT, int N>
+inline Batch<TT, N> operator*(TT s, Batch<TT, N> const& f) {
+  return Batch{(s * f.lanes).eval()};
+}
+
+template <class TScalar>
+struct BatchTrait {
+  using Scalar = TScalar;
+  using ScalarBatch = TScalar;
+  static int constexpr kBatchSize = 1;
+  static bool constexpr kIsBatch = false;
+
+  static bool anyLessEqual(TScalar const& lhs, TScalar const& rhs) {
+    return lhs < rhs;
+  }
+
+  static bool allLessEqual(TScalar const& lhs, TScalar const& rhs) {
+    return lhs < rhs;
+  }
+};
+
+template <class TScalar, int kNum>
+struct BatchTrait<Batch<TScalar, kNum>> {
+  using Scalar = TScalar;
+  using ScalarBatch = Batch<TScalar, kNum>;
+  static int constexpr kBatchSize = kNum;
+  static bool constexpr kIsBatch = true;
+
+  static bool anyLessEqual(ScalarBatch const& lhs, ScalarBatch const& rhs) {
+    return (lhs.lanes < rhs.lanes).any();
+  }
+
+  static bool anyLessEqual(ScalarBatch const& lhs, Scalar const& rhs) {
+    return (lhs.lanes < rhs).any();
+  }
+
+  static bool allLessEqual(ScalarBatch const& lhs, ScalarBatch const& rhs) {
+    return (lhs.lanes < rhs.lanes).all();
+  }
+
+  static bool allLessEqual(ScalarBatch const& lhs, Scalar const& rhs) {
+    return (lhs.lanes < rhs).all();
+  }
+};
+
+}  // namespace sophus2
+
+namespace Eigen {
+
+// This is mirrored from ceres::Jet.
+template <class TT, int kNum>
+struct NumTraits<sophus2::Batch<TT, kNum>> {
+  using Real = sophus2::Batch<TT, kNum>;
+  using NonInteger = sophus2::Batch<TT, kNum>;
+  using Nested = sophus2::Batch<TT, kNum>;
+  using Literal = sophus2::Batch<TT, kNum>;
+  enum {
+    IsComplex = 0,
+    IsInteger = 0,
+    IsSigned,
+    ReadCost = 1,
+    AddCost = 1,
+    MulCost = 2,
+    HasFloatingPoint = 1,
+    RequireInitialization = 1
+  };
+
+  static sophus2::Batch<TT, kNum> dummy_precision() {
+    return sophus2::Batch<TT, kNum>(1e-12);
+  }
+
+  inline static Real epsilon() {
+    return Real(std::numeric_limits<TT>::epsilon());
+  }
+
+  inline static int digits10() { return NumTraits<TT>::digits10(); }
+
+  inline static Real highest() {
+    return Real((std::numeric_limits<TT>::max)());
+  }
+  inline static Real lowest() {
+    return Real(-(std::numeric_limits<TT>::max)());
+  }
+};
+
+template <class BinaryOp, class TT, int kNum>
+struct ScalarBinaryOpTraits<sophus2::Batch<TT, kNum>, TT, BinaryOp> {
+  using ReturnType = sophus2::Batch<TT, kNum>;
+};
+template <class BinaryOp, class TT, int kNum>
+struct ScalarBinaryOpTraits<TT, sophus2::Batch<TT, kNum>, BinaryOp> {
+  using ReturnType = sophus2::Batch<TT, kNum>;
+};
+
+}  // namespace Eigen

--- a/cpp/sophus2/linalg/batch_test.cpp
+++ b/cpp/sophus2/linalg/batch_test.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2011, Hauke Strasdat
+// Copyright (c) 2012, Steven Lovegrove
+// Copyright (c) 2021, farm-ng, inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include "sophus2/linalg/batch.h"
+
+#include "sophus2/linalg/orthogonal.h"
+
+#include <gtest/gtest.h>
+
+using namespace sophus;
+
+TEST(batch, unit) {
+  int constexpr kNumBatches = 8;
+  int constexpr kM = 7;
+  int constexpr kN = 3;
+  int constexpr kO = 5;
+
+  std::vector<Eigen::Matrix<double, kM, kN>> mat7x3_vec;
+  std::vector<Eigen::Matrix<double, kN, kO>> mat3x5_vec;
+  std::vector<Eigen::Matrix<double, kM, kO>> mat7x5_vec;
+
+  for (int b = 0; b < kNumBatches; ++b) {
+    mat7x3_vec.push_back(Eigen::Matrix<double, kM, kN>::Random());
+    mat3x5_vec.push_back(Eigen::Matrix<double, kN, kO>::Random());
+  }
+
+  Eigen::Matrix<Batch<double, kNumBatches>, kM, kN> batched_mat_7x3;
+  for (int m = 0; m < kM; ++m) {
+    for (int n = 0; n < kN; ++n) {
+      Batch<double, kNumBatches>& batch = batched_mat_7x3(m, n);
+      for (int b = 0; b < kNumBatches; ++b) {
+        batch.b[b] = mat7x3_vec[b](m, n);
+      }
+    }
+  }
+
+  Eigen::Matrix<Batch<double, kNumBatches>, kN, kO> batched_mat_3x5;
+  for (int n = 0; n < kN; ++n) {
+    for (int o = 0; o < kO; ++o) {
+      Batch<double, kNumBatches>& batch = batched_mat_3x5(n, o);
+      for (int b = 0; b < kNumBatches; ++b) {
+        batch.b[b] = mat3x5_vec[b](n, o);
+      }
+    }
+  }
+
+  for (int b = 0; b < kNumBatches; ++b) {
+    mat7x5_vec.push_back(mat7x3_vec[b] * mat3x5_vec[b]);
+  }
+  Eigen::Matrix<Batch<double, kNumBatches>, kM, kO> batched_mat_7x5 =
+      batched_mat_7x3 * batched_mat_3x5;
+
+  for (int m = 0; m < kM; ++m) {
+    for (int o = 0; o < kO; ++o) {
+      Batch<double, kNumBatches>& batch = batched_mat_7x5(m, o);
+      for (int b = 0; b < kNumBatches; ++b) {
+        FARM_ASSERT_NEAR(batch.b[b], mat7x5_vec[b](m, o), 0.001);
+      }
+    }
+  }
+}

--- a/cpp/sophus2/manifold/CMakeLists.txt
+++ b/cpp/sophus2/manifold/CMakeLists.txt
@@ -28,11 +28,9 @@ farm_ng_add_library(sophus_manifold
 
 target_link_libraries(sophus_manifold INTERFACE sophus2_linalg)
 
-if(${BUILD_SOPHUS_TESTS})
   foreach(test_basename ${sophus_manifold_src_prefixes})
     farm_ng_add_test(${test_basename}
                           PARENT_LIBRARY sophus_manifold
                           LINK_LIBRARIES sophus_manifold
                           LABELS small)
   endforeach()
-endif()

--- a/cpp/sophus2/manifold/complex.h
+++ b/cpp/sophus2/manifold/complex.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "sophus2/common/common.h"
 #include "sophus2/concepts/division_ring.h"
+#include "sophus2/linalg/batch.h"
 #include "sophus2/linalg/vector_space.h"
 
 namespace sophus2 {
@@ -16,11 +17,13 @@ namespace sophus2 {
 /// Generic complex number implementation
 ///
 /// Impl class without any storage, but only static methods.
-template <class TScalar>
+template <class TBatch>
 class ComplexImpl {
  public:
   /// The underlying scalar type.
-  using Scalar = TScalar;
+  using Scalar = typename BatchTrait<TBatch>::ScalarBatch;
+  static int constexpr kNumSingles = BatchTrait<TBatch>::kNumSingles;
+
   /// A complex number is a tuple.
   static int constexpr kNumParams = 2;
   /// Complex multiplication is commutative (and it is a field itself).

--- a/cpp/sophus2/manifold/complex_test.cpp
+++ b/cpp/sophus2/manifold/complex_test.cpp
@@ -19,4 +19,9 @@ TEST(complex, unit) { Complex<double> z; }
 TEST(complex, prop_test) {
   test::DivisionRingTestSuite<Complex<double>>::runAllTests("Complex<double>");
   test::DivisionRingTestSuite<Complex<float>>::runAllTests("Complex<float>");
+
+  test::DivisionRingTestSuite<Complex<Batch<double, 8>>>::runAllTests(
+      "Batch<double, 8>");
+
+  Complex<Batch<double, 8>> complex;
 }

--- a/cpp/sophus2/manifold/unit_vector.h
+++ b/cpp/sophus2/manifold/unit_vector.h
@@ -155,6 +155,7 @@ class UnitVectorImpl {
     Tangent tail = params.template tail<kDof>();
     Scalar theta = tail.norm();
 
+    using std::abs;
     if (abs(theta) < kEpsilon<Scalar>) {
       return atan2(Scalar(0.0), x) * kUnitX;
     }

--- a/cpp/sophus2/sensor/camera_distortion/brown_conrady.h
+++ b/cpp/sophus2/sensor/camera_distortion/brown_conrady.h
@@ -90,6 +90,7 @@ class BrownConradyTransform {
     PixelImage<TScalar> xy = uv_normalized;
 
     for (int i = 0; i < 50; ++i) {
+      using std::abs;
       TScalar x = xy[0];
       TScalar y = xy[1];
 


### PR DESCRIPTION
**Core feature:** ``Batch<class TT, int kNum>`` template class, to enable full batch / SIMD processing

**How does this work?**

Eigen matrices are templates, where the first element is a Scalar type, e.g. ``double`` in this example: ``Eigen::Matirx3d = Eigen::Matrix<double, 3, 3>``.

However, there is a ``Eigen::NumTraits`` trait class, to support other "scalars". A relatively well-known example is ``ceres::Jet`` types. Here, ``ceres::Jet<...>`` is a dual number pair.

Similarly, we define a "scalar" type called ``Batch<...>``:

```
template <class TT, int kNum>
struct Batch {
  Batch() {}

 [...]

  Eigen::Array<TT, kNum, 1> b;
};
```

which contains an Eigen array ``b``.

And we specialize the ``Eigen::NumTraits`` template:


```
template <class TT, int kNum>
struct NumTraits<sophus2::Batch<TT, kNum>> {
  using Real = sophus2::Batch<TT, kNum>;
```

Now, we can perform batched matrix operations such as matrix x matrix multiplication:

```
  Eigen::Matrix<Batch<double, kNumBatches>, kM, kN> batched_mat_7x3;
  Eigen::Matrix<Batch<double, kNumBatches>, kN, kO> batched_mat_3x5;
  
  Eigen::Matrix<Batch<double, kNumBatches>, kM, kO> batched_mat_7x5 =
      batched_mat_7x3 * batched_mat_3x5;
```

Let's zoom in what is going on here. We note that kNumBatches is identical for all three matrices, and this is the critical aspect of these type of batch operations. Now, if kNumBatches is chosen wisely (e.g. kNumBatches==8), we will get SIMD (e.g. AVX on AMD64 CPUs) operations. 

The key aspect is, compared to using non-batch Eigen matrices, that we will get will get SIMD instructions, independent of what dimensions we choose for ``kM, kN, kO`` as long as `` kNumBatches`` is a multiple of 8 (or whatever the actual logic in Eigen is; the website is down at the moment) and corresponding compiler setttings are enabled.

_For AMD64 cpus,  you typically need to enable AVX instructions explicitly (https://stackoverflow.com/a/44962907). I did experimentally verify that the matrix matrix multiplcation in the test did genereate  AVX instructions - some month ago..._