### PR TITLE
feat: thread-boundary correct start/stop, better stats

### DIFF
--- a/cpp/farm_ng/core/logging/logger.h
+++ b/cpp/farm_ng/core/logging/logger.h
@@ -516,9 +516,8 @@ struct UnwrapImpl {
 
 template <class TWrapper>
 auto unwrapImpl(
-    TWrapper& wrapper,
-    char const* wrapper_cstr,
-    ::farm_ng::ErrorDetail detail) -> decltype(*wrapper) {
+    TWrapper& wrapper, char const* wrapper_cstr, ::farm_ng::ErrorDetail detail)
+    -> decltype(*wrapper) {
   return UnwrapImpl<TWrapper>::impl(wrapper, wrapper_cstr, std::move(detail));
 }
 

--- a/cpp/sophus2/geometry/point_transform.h
+++ b/cpp/sophus2/geometry/point_transform.h
@@ -145,7 +145,7 @@ template <class TT>
     sophus2::Isometry3<TT> const& bar_from_daz,
     InverseDepthPoint3<TT> const& inverse_depth_point_in_daz)
     -> Eigen::Matrix<TT, 2, 6> {
-   return dxProjExpXTransformPointAt0(
+  return dxProjExpXTransformPointAt0(
              foo_from_bar * bar_from_daz, inverse_depth_point_in_daz) *
          foo_from_bar.adj();
 }


### PR DESCRIPTION
stopwatch now has the following stats:

- total number of calls
- LAST (and 2nd last) timing, to keep stats of recent events
- over a sliding window of 30
  * MEDIAN
  * min
  * max