### PR TITLE
Fix plotting component name

### DIFF
--- a/cpp/farm_ng/core/plotting/plotting_component.cpp
+++ b/cpp/farm_ng/core/plotting/plotting_component.cpp
@@ -25,7 +25,7 @@ namespace farm_ng {
 struct PlottingComponentImpl : public Component, public PlottingComponent {
   PlottingComponentImpl(
       Context const& ctx, RemotePlottingClient::Params const& params)
-      : Component(ctx, "plotting", this, ""),
+      : Component(ctx, "other", this, "plotting"),
         input_messages_(
             this,
             "on_messages",


### PR DESCRIPTION
The constructor arguments were passed in the incorrect order, resulting in the "path" part of the URI for the component being "" and the scheme part of the URI being "plotting".

This resolves that issue.