### PR TITLE
Update workflow to use macos-12 since macos-11 is deprecated

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Deprecation notice: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

We're using currently macos-12 on our python CI. Also, I found the following note on our ci_python workflow:
```
        # Using macos-12 bc:
        #  1. they removed support for python 3.8 & 3.9 on macos-14 (now macos-latest)
        #    - See: https://github.com/actions/setup-python/issues/696#issuecomment-2071769156
        #  2. `test_pose` fails on macos-13 and macos-14 (but not macos-12)
        os: [ubuntu-latest, macos-12]
```