### PR TITLE
CI fixes: update precommit | lock grpcio, protobuf versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -88,8 +88,12 @@ repos:
       - id: ruff
         exclude: (thirdparty|cpp/sophus)/.*$
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+
+  # TODO: Set ``rev: v1.7.6`` once the release is available.
+  # See: https://github.com/PyCQA/docformatter/issues/293
+  - repo: https://github.com/myint/docformatter
+    # rev: v1.7.6
+    rev: "eb1df347edd128b30cd3368dddc3aa65edcfac38"
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = [
     "setuptools",
     "farm-ng-package",
-    "pybind11"
+    "pybind11",
+    "wheel",
+    "grpcio==1.64.1",
+    "grpcio-tools==1.64.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     farm_ng_package
     protobuf==5.27.2
     grpcio==1.64.1
+    grpcio-tools==1.64.1
     psutil
     numpy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ classifiers =
 
 [options]
 python_requires = >=3.8
-setup_requires =
-    wheel
 install_requires =
     farm_ng_package
     protobuf==5.27.2
@@ -55,6 +53,7 @@ dev =
     mypy
     types-protobuf
     pylint
+    grpcio==1.64.1
     grpcio-tools==1.64.1
     mypy-protobuf
     pylint-protobuf

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     farm_ng_package
     protobuf==5.27.2
     grpcio==1.64.1
-    grpcio-tools==1.64.1
     psutil
     numpy
 
@@ -55,7 +54,7 @@ dev =
     mypy
     types-protobuf
     pylint
-    grpcio-tools
+    grpcio-tools==1.64.1
     mypy-protobuf
     pylint-protobuf
     anyio

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ setup_requires =
     wheel
 install_requires =
     farm_ng_package
-    protobuf
-    grpcio
+    protobuf==5.27.2
+    grpcio==1.64.1
     psutil
     numpy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,22 +22,10 @@ classifiers =
 [options]
 python_requires = >=3.8
 install_requires =
-    farm_ng_package
     protobuf==5.27.2
     grpcio==1.64.1
-    grpcio-tools==1.64.1
     psutil
     numpy
-
-tests_require =
-    pytest
-    pytest-runner
-    pytest-mypy
-    pylint-protobuf
-    types-protobuf
-    anyio
-
-test_suite = tests
 
 package_dir =
     = py
@@ -46,18 +34,21 @@ packages =
     farm_ng.core
 
 [options.extras_require]
-dev =
+test =
     pytest
     pytest-mypy
-    pre-commit
-    mypy
-    types-protobuf
-    pylint
-    grpcio==1.64.1
-    grpcio-tools==1.64.1
-    mypy-protobuf
+    pytest-runner
     pylint-protobuf
     anyio
+    types-protobuf
+    grpcio-tools==1.64.1
+
+dev =
+    %(test)s
+    pre-commit
+    mypy
+    pylint
+    mypy-protobuf
 
 [mypy]
 files = py/farm_ng, py/tests


### PR DESCRIPTION
lock protobuf and grpcio on last known stable versions with our images. 5.28+ is throwing segmentation errors.