### PR TITLE
Suppress build warnings for thirdparty C++ code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,13 +101,13 @@ ext_modules = [
             # suppress warnings from them.
             # This might allow removing some of the -Wno-* flags above.
             "-isystem",
-            source_dir / "cpp/thirdparty/expected/include",
+            str(source_dir / "cpp/thirdparty/expected/include"),
             "-isystem",
-            source_dir / "cpp/thirdparty/farm_pp/include",
+            str(source_dir / "cpp/thirdparty/farm_pp/include"),
             "-isystem",
-            source_dir / "cpp/thirdparty/fmt/include",
+            str(source_dir / "cpp/thirdparty/fmt/include"),
             "-isystem",
-            source_dir / "cpp/thirdparty/eigen",
+            str(source_dir / "cpp/thirdparty/eigen"),
         ],
         include_dirs=[
             source_dir / "cpp",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ if sys.platform.startswith("darwin"):
         "-std=c++20",
         "-mmacosx-version-min=11.0",
         "-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS=1",
+        # GCC and Clang may support slightly different sets of warning options.
+        # GCC will tolerate unknown ones by default, but Clang needs this.
+        "-Wno-unknown-warning-option",
     ]
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
 

--- a/setup.py
+++ b/setup.py
@@ -91,20 +91,26 @@ ext_modules = [
             "-Wall",
             "-Wextra",
             "-Werror",
-            "-Wno-unknown-warning-option",
             "-Wno-unused-parameter",
             "-Wno-missing-field-initializers",
             "-Wno-unused-but-set-variable",
             "-Wno-unused-variable",
             "-Wno-unused-function",
             "-Wno-maybe-uninitialized",
+            # Treat thirdparty libraries as system header directories to
+            # suppress warnings from them.
+            # This might allow removing some of the -Wno-* flags above.
+            "-isystem",
+            source_dir / "cpp/thirdparty/expected/include",
+            "-isystem",
+            source_dir / "cpp/thirdparty/farm_pp/include",
+            "-isystem",
+            source_dir / "cpp/thirdparty/fmt/include",
+            "-isystem",
+            source_dir / "cpp/thirdparty/eigen",
         ],
         include_dirs=[
             source_dir / "cpp",
-            source_dir / "cpp/thirdparty/expected/include",
-            source_dir / "cpp/thirdparty/farm_pp/include",
-            source_dir / "cpp/thirdparty/fmt/include",
-            source_dir / "cpp/thirdparty/eigen",
         ],
     ),
 ]


### PR DESCRIPTION
Try to unblock ARM wheel builds for SWE-427.

The Python build includes building some C++ code via Pybind, including several thirdparty libraries. We have strict compile-time checks enabled (`-Wall -Wextra -Werror`) which is a good practice, but thirdparty headers often don't conform to all of the checks, especially as newer compiler versions add more of them. To date, we've worked around that by suppressing specific warnings with `-Wno-*` flags, but that's brittle:
* We might like those warnings to be flagged in our own code.
* We have to keep adding to the list as OS/tooling upgrades bring in newer GCC versions.

It's better to suppress warnings for the thirdparty code, but keep strict checking for our code.