### PR TITLE
Fix Kannala-Brandt undistortion seed

### DIFF
--- a/cpp/sophus/sensor/camera_distortion/kannala_brandt.h
+++ b/cpp/sophus/sensor/camera_distortion/kannala_brandt.h
@@ -115,8 +115,9 @@ class KannalaBrandtK3Transform {
 
     const TScalar rth = sqrt(rth2);
 
-    // Use Newtons method to solve for theta, 50 iterations max
-    TScalar th = sqrt(rth);
+    // The normalized distorted radius is d(theta), so use its linear term as
+    // the initial estimate when inverting the distortion polynomial.
+    TScalar th = rth;
     for (int i = 0; i < 500; ++i) {
       const TScalar th2 = th * th;
       const TScalar th4 = th2 * th2;

--- a/cpp/sophus/sensor/camera_model_test.cpp
+++ b/cpp/sophus/sensor/camera_model_test.cpp
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 using namespace sophus;
 
 double constexpr kEps = 1e-5;
@@ -232,6 +234,25 @@ TEST(camera_model, projection_round_trip) {
           }
         }
       }
+    }
+  }
+}
+
+TEST(camera_model, kannala_brandt_projection_round_trip) {
+  KannalaBrandtK3Transform::Params<double> params;
+  params << 400.0, 420.0, 320.0, 240.0, -0.08, 0.02, -0.002, 0.0001;
+
+  for (double theta : {0.001, 0.05, 0.3, 0.7, 1.1, 1.4}) {
+    for (double azimuth : {0.0, 0.7, 1.9, -2.4}) {
+      Eigen::Vector2d const point_in_camera_z1_plane =
+          std::tan(theta) *
+          Eigen::Vector2d(std::cos(azimuth), std::sin(azimuth));
+      Eigen::Vector2d const pixel =
+          KannalaBrandtK3Transform::distort(params, point_in_camera_z1_plane);
+      Eigen::Vector2d const recovered_point =
+          KannalaBrandtK3Transform::undistort(params, pixel);
+
+      EXPECT_TRUE(recovered_point.isApprox(point_in_camera_z1_plane, 1e-10));
     }
   }
 }


### PR DESCRIPTION
## Summary

- initialize the Kannala-Brandt inverse Newton solve from the distorted angular radius
- document why the linear term is the appropriate initial estimate
- add round-trip coverage across multiple angles and azimuths, including wide-angle rays

## Why

The forward model computes the normalized distorted radius as
`d(theta) = theta * (1 + k0*theta^2 + ... + k3*theta^8)`. Its first-order inverse estimate is therefore `theta = rth`. The previous `sqrt(rth)` seed does not follow from the model and is especially disproportionate near the optical axis.

Using `atan(rth)` would instead treat `rth` as an undistorted z=1-plane radius, but here it is already the distorted angular radius.

Closes #258.

## Validation

- compiled the affected header with the repository's pinned Eigen, fmt, and expected revisions
- exercised 24 project/unproject round trips from `theta = 0.001` to `1.4` radians over four azimuths
- maximum observed round-trip error: `2.24e-14`
- `git diff --check`

The full CMake suite was not run locally because this checkout does not have the project's prebuilt external dependency prefix; CI can exercise the repository-wide matrix.
