### PR TITLE
Add async EventsFileWriter methods

### DIFF
--- a/py/farm_ng/core/event_service_recorder.py
+++ b/py/farm_ng/core/event_service_recorder.py
@@ -163,13 +163,13 @@ class EventServiceRecorder:
                 # Add any header events added during recording
                 while self.header_deque:
                     event, payload = self.header_deque.popleft()
-                    writer.add_header_event(event, payload, write=True)
+                    await writer.add_header_event_async(event, payload, write=True)
                 # await a new event and payload, and write it to the file
                 event, payload = await self.record_queue.get()
                 event.timestamps.append(
                     get_monotonic_now(semantics=StampSemantics.FILE_WRITE),
                 )
-                writer.write_event_payload(event, payload)
+                await writer.write_event_payload_async(event, payload)
 
     async def subscribe(
         self,

--- a/py/farm_ng/core/events_file_writer.py
+++ b/py/farm_ng/core/events_file_writer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import struct
+from functools import partial
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, cast
+from typing import IO, TYPE_CHECKING, Callable, cast
 
 # pylint can't find Event or Uri in protobuf generated files
 # https://github.com/protocolbuffers/protobuf/issues/10372
@@ -93,6 +95,7 @@ class EventsFileWriter:
         self._file_idx: int = 0
 
         self._header_events: dict[str, tuple[Event, bytes]] = {}
+        self._async_write_lock: asyncio.Lock | None = None
         for (event, payload) in header_events or []:
             self.add_header_event(event, payload)
 
@@ -200,6 +203,23 @@ class EventsFileWriter:
             if write:
                 self.write_event_payload(event, payload)
 
+    async def add_header_event_async(
+        self,
+        event: Event,
+        payload: bytes,
+        write: bool = False,
+    ) -> None:
+        """Add a header event without blocking the running event loop.
+
+        Args:
+            event: Event to add.
+            payload: Payload to add.
+            write: If True, write the header event to the file. Defaults to False.
+        """
+        await self._run_in_executor(
+            partial(self.add_header_event, event, payload, write),
+        )
+
     def write_header_events(self) -> None:
         """Write the header events to the file.
 
@@ -238,6 +258,21 @@ class EventsFileWriter:
         self._file_stream = None
         return self.is_closed()
 
+    async def _run_in_executor(self, callback: Callable[[], None]) -> None:
+        """Run a file operation serially without blocking the event loop."""
+        if self._async_write_lock is None:
+            self._async_write_lock = asyncio.Lock()
+
+        async with self._async_write_lock:
+            future = asyncio.get_running_loop().run_in_executor(None, callback)
+            try:
+                await asyncio.shield(future)
+            except asyncio.CancelledError:
+                # A running executor job cannot be cancelled. Wait for it to finish so
+                # the writer is not closed while the background thread is still writing.
+                await future
+                raise
+
     def write_event_payload(self, event: Event, payload: bytes) -> None:
         if self.is_closed():
             msg = f"Event log is not open: {self.file_name}"
@@ -268,6 +303,12 @@ class EventsFileWriter:
             if not self.open():
                 msg = f"Failed to open file: {self.file_name}"
                 raise RuntimeError(msg)
+
+    async def write_event_payload_async(self, event: Event, payload: bytes) -> None:
+        """Write an event and payload without blocking the running event loop."""
+        await self._run_in_executor(
+            partial(self.write_event_payload, event, payload),
+        )
 
     def _write_raw(
         self,
@@ -313,3 +354,22 @@ class EventsFileWriter:
             timestamps.append(get_system_clock_now(semantics=StampSemantics.FILE_WRITE))
         uri = make_proto_uri(path=path, message=message)
         self._write_raw(uri=uri, message=message, timestamps=timestamps)
+
+    async def write_async(
+        self,
+        path: str,
+        message: Message,
+        timestamps: list[Timestamp] | None = None,
+        write_stamps: bool = True,
+    ) -> None:
+        """Write a message without blocking the running event loop.
+
+        Args:
+            path: Path to the message.
+            message: Message to write.
+            timestamps: List of timestamps to write.
+            write_stamps: If True, append FILE_WRITE timestamps to the event when writing.
+        """
+        await self._run_in_executor(
+            partial(self.write, path, message, timestamps, write_stamps),
+        )

--- a/py/tests/_asyncio/test_events_file_writer.py
+++ b/py/tests/_asyncio/test_events_file_writer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+from farm_ng.core.event_pb2 import Event
+from farm_ng.core.events_file_reader import EventsFileReader
+from farm_ng.core.events_file_writer import EventsFileWriter
+from farm_ng.core.uri import make_proto_uri
+from google.protobuf.wrappers_pb2 import Int32Value, StringValue
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_write_async(file_base: Path) -> None:
+    with EventsFileWriter(file_base=file_base) as writer:
+        await asyncio.gather(
+            *(
+                writer.write_async("test_path", Int32Value(value=value))
+                for value in range(1, 11)
+            ),
+        )
+
+    with EventsFileReader(file_name=file_base.with_suffix(".0000.bin")) as reader:
+        messages = [event_log.read_message() for event_log in reader.get_index()]
+
+    assert messages == [Int32Value(value=value) for value in range(1, 11)]
+
+
+async def test_write_event_payload_async(file_base: Path) -> None:
+    message = StringValue(value="test_payload")
+    payload = message.SerializeToString()
+    event = Event(
+        uri=make_proto_uri(path="/test_path", message=message),
+        payload_length=len(payload),
+    )
+
+    with EventsFileWriter(file_base=file_base) as writer:
+        await writer.write_event_payload_async(event, payload)
+
+    with EventsFileReader(file_name=file_base.with_suffix(".0000.bin")) as reader:
+        event_log = reader.read_next_event()
+        assert event_log.read_message() == message
+
+
+async def test_write_async_does_not_block_event_loop(
+    file_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_started = threading.Event()
+    allow_write = threading.Event()
+
+    with EventsFileWriter(file_base=file_base) as writer:
+        write = writer.write
+
+        def blocking_write(*args, **kwargs) -> None:
+            write_started.set()
+            if not allow_write.wait(timeout=2):
+                error_message = "test did not release the file write"
+                raise TimeoutError(error_message)
+            write(*args, **kwargs)
+
+        monkeypatch.setattr(writer, "write", blocking_write)
+        task = asyncio.create_task(
+            writer.write_async("test_path", Int32Value(value=1)),
+        )
+
+        for _ in range(100):
+            if write_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        assert write_started.is_set()
+        assert not task.done()
+        allow_write.set()
+        await task
+
+
+async def test_cancellation_waits_for_active_write(
+    file_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_started = threading.Event()
+    allow_write = threading.Event()
+
+    with EventsFileWriter(file_base=file_base) as writer:
+        write = writer.write
+
+        def blocking_write(*args, **kwargs) -> None:
+            write_started.set()
+            if not allow_write.wait(timeout=2):
+                error_message = "test did not release the file write"
+                raise TimeoutError(error_message)
+            write(*args, **kwargs)
+
+        monkeypatch.setattr(writer, "write", blocking_write)
+        task = asyncio.create_task(
+            writer.write_async("test_path", Int32Value(value=1)),
+        )
+
+        for _ in range(100):
+            if write_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        assert write_started.is_set()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        allow_write.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.fixture()
+def file_base(tmp_path: Path) -> Path:
+    return tmp_path / "test_events_file"


### PR DESCRIPTION
## Summary

- add asynchronous `write_async`, `write_event_payload_async`, and `add_header_event_async` APIs while keeping the existing synchronous methods unchanged
- serialize asynchronous file operations through `run_in_executor` so concurrent callers cannot interleave event bytes
- wait for an in-flight executor write during cancellation, preventing the writer from closing while a background thread is still using the file
- update `EventServiceRecorder` to await header and payload writes instead of blocking its event loop
- add coverage for concurrent writes, event payload writes, event-loop responsiveness, and cancellation safety

## Motivation

`EventServiceRecorder.record()` is asynchronous, but it currently performs file writes synchronously on the event-loop thread. Slow storage can therefore delay subscriptions and other coroutine work. This implements the executor-based approach discussed in #62 without adding another dependency or changing the synchronous API.

Closes #62.

## Validation

- `13 passed` across the new async writer tests, recorder tests, and existing synchronous writer tests
- all async test files pass when executed independently, matching the repository CI strategy
- `39 passed` in the remaining pure-Python sequential suite
- `mypy py/farm_ng` — 28 source files checked successfully
- Black 22.3, Ruff 0.0.284, codespell, and docformatter checks pass for all changed files

The local C++ extension build was not available because the macOS toolchain could not locate standard C++ headers; the unrelated pybind-only test was therefore not run locally.
